### PR TITLE
Fix missing files in Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,8 +2,8 @@ codecov:
   require_ci_to_pass: yes
   disable_default_path_fixes: yes
 
-# fixes:
-#   - "/home/runner/work/erdantic/erdantic/::"
+fixes:
+  - "::erdantic/"
 
 coverage:
   precision: 1

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,8 +2,8 @@ codecov:
   require_ci_to_pass: yes
   disable_default_path_fixes: yes
 
-fixes:
-  - "/home/runner/work/erdantic/erdantic/erdantic/::erdantic/"
+# fixes:
+#   - "/home/runner/work/erdantic/erdantic/::"
 
 coverage:
   precision: 1

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -17,3 +17,6 @@ coverage:
 
 comment:
   layout: "diff,flags,tree"
+
+fixes:
+  - "::erdantic/"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -19,4 +19,4 @@ comment:
   layout: "diff,flags,tree"
 
 fixes:
-  - "::erdantic/"
+  - "erdantic/::"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,9 @@
 codecov:
   require_ci_to_pass: yes
+  disable_default_path_fixes: yes
+
+fixes:
+  - "/home/runner/work/erdantic/erdantic/erdantic/::erdantic/"
 
 coverage:
   precision: 1
@@ -17,6 +21,3 @@ coverage:
 
 comment:
   layout: "diff,flags,tree"
-
-fixes:
-  - "/home/runner/work/erdantic/erdantic/erdantic/::erdantic/"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -19,4 +19,4 @@ comment:
   layout: "diff,flags,tree"
 
 fixes:
-  - "erdantic/::"
+  - "/home/runner/work/erdantic/erdantic/erdantic/::erdantic/"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,7 +9,7 @@ coverage:
     project: # Coverage of whole project
       default:
         target: auto # Coverage target to pass; auto is base commit
-        threshold: 2% # Allow coverage to drop by this much vs. base and still pass
+        threshold: 5% # Allow coverage to drop by this much vs. base and still pass
     patch: # Coverage of lines in this change
       default:
         target: 80% # Coverage target to pass

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest] #[ubuntu-latest, macos-latest] # [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest] # [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
@@ -40,12 +40,6 @@ jobs:
       - name: Run tests
         run: |
           make test
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
-        with:
-          name: coverage_${{ matrix.python-version }}.xml
-          path: ./coverage.xml
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest] # [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest] #[ubuntu-latest, macos-latest] # [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
@@ -40,6 +40,19 @@ jobs:
       - name: Run tests
         run: |
           make test
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage_${{ matrix.python-version }}.xml
+          path: ./coverage.xml
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true
+        if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Build distribution and test installation
         shell: bash
@@ -70,10 +83,3 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 1
-
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.xml
-          fail_ci_if_error: true
-        if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ clean-pyc: ## remove Python file artifacts
 clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/
 	rm -f .coverage
+	rm -f coverage.xml
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,3 @@ addopts = --cov=erdantic --cov-report=term --cov-report=html --cov-report=xml
 
 [coverage:run]
 source = erdantic/
-#include = erdantic/**.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,6 @@ ignore_missing_imports = True
 testpaths = tests/
 addopts = --cov=erdantic --cov-report=term --cov-report=html --cov-report=xml
 
-[coverage:report]
+[coverage:run]
+source = ./
 include = erdantic/**.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,5 +10,5 @@ testpaths = tests/
 addopts = --cov=erdantic --cov-report=term --cov-report=html --cov-report=xml
 
 [coverage:run]
-source = ./
-include = erdantic/**.py
+source = erdantic/
+#include = erdantic/**.py


### PR DESCRIPTION
We were missing the files `erdantic/pydantic.py` and `erdantic/dataclasses.py` files even though they show up in `coverage.xml` both when run locally and in the CI. 

Context: Codecov apparently struggles with file paths in the coverage report. There is a whole [docs page](https://docs.codecov.io/docs/fixing-paths) about it which is simultaneously in depth but still not clear enough about what the specific end result needs to be. However, Codecov has some automatic stuff they do to resolve the paths, so most projects generally don't need to do anything.

Our particular bug seemed to have happened because Codecov's automatic resolution has a bug. Best guess is that these two missing files aliased with `erdantic/examples/pydantic.py` and `erdantic/examples/dataclasses.py` respectively because Codecov's pattern matching is not sufficiently greedy. 

There are two things that have to work for a fix to be successful:

- Codecov is able to display all files in its list of files
- Clicking on a file links correctly to the sourc ecode

It can be the case that one of these is working but not the other. 

## Fixing it

### Step 1: Disable automatic resolution

Disable the automatic resolution with `disable_default_path_fixes: yes` in `codecov.yml`. Even if manual fixes would be right without automatic resolution, the automatic resolution still kicks in and causes aliasing anyways.

### Step 2: Set path fix manually

Set a manual path fix in `codecov.yml` as described in this [docs page](https://docs.codecov.io/docs/fixing-paths). 

What to set it to? The general principle appears to be that we need the "current directory" of Codecov to match "current directory" of `coverage.xml`.

`coverage.xml`: As shown in the screenshot below, we see the two "packages" have paths of `.` and `examples`. So that means coverage's "current directory" is inside the `erdantic/` directory of our repo.

<img width="1008" alt="Screen Shot 2021-02-06 at 9 34 49 PM" src="https://user-images.githubusercontent.com/2721979/107137660-a28d1b00-68c3-11eb-8a5a-681b143cfdf0.png">

Codecov: This by default appears to be the repo root.

So the gist of the fix is that we move Codecov's "current directory" into `erdantic/` to match `coverage.xml`. We do this by "moving" Codecov's root to `erdantic/` by the docs. 