### PR TITLE
Unify diagram, model, and field creation

### DIFF
--- a/erdantic/base.py
+++ b/erdantic/base.py
@@ -113,6 +113,11 @@ class Model(ABC):
     def __hash__(self):  # pragma: no cover
         pass
 
+    @property
+    def id(self) -> str:
+        """Unique identifier for this Model node."""
+        return f"{self.name}__{hash(self)}"
+
     def dot_label(self) -> str:
         """Returns the DOT language "HTML-like" syntax specification of a table for this data
         model. It is used as the `label` attribute of data model's node in the graph's DOT

--- a/erdantic/base.py
+++ b/erdantic/base.py
@@ -1,23 +1,26 @@
 from abc import ABC, abstractmethod
 import inspect
-from typing import Any, Callable, Dict, List, Type
+from typing import Any, Callable, Dict, Generic, List, Type, TypeVar
 
-from erdantic.typing import repr_type, repr_type_with_mro
+from erdantic.typing import Final, repr_type, repr_type_with_mro
 
 
 _row_template = """<tr><td>{name}</td><td port="{name}">{type_name}</td></tr>"""
 
 
-class Field(ABC):
+FT = TypeVar("FT", bound=Any)
+"""Bounded type variable for a field object adapted by adapter class
+[`Field`][erdantic.base.Field]."""
+
+
+class Field(ABC, Generic[FT]):
     """Abstract base class that adapts a field object of a data model class to work with erdantic.
-    Concrete implementations should subclass and implement methods.
+    Concrete implementations should subclass and implement abstract methods.
     """
 
-    field: Any
-
     @abstractmethod
-    def __init__(self, field: Any):
-        pass
+    def __init__(self, field: FT):
+        self.field: Final[FT] = field
 
     @property
     @abstractmethod
@@ -81,17 +84,20 @@ _table_template = """
 """
 
 
-class Model(ABC):
+MT = TypeVar("MT", bound=Any)
+"""Bounded type variable for a data model class adapted by adapter class
+[`Model`][erdantic.base.Model]."""
+
+
+class Model(ABC, Generic[MT]):
     """Abstract base class that adapts a data model class to work with erdantic. Instances
-    representing a node in our entity relationship diagram graph. Concrete implementations should
-    subclass and implement methods.
+    represent a node in our entity relationship diagram graph. Concrete implementations should
+    subclass and implement abstract methods.
     """
 
-    model: Any
-
     @abstractmethod
-    def __init__(self, model: Any):
-        pass
+    def __init__(self, model: MT):
+        self.model: Final[MT] = model
 
     @property
     @abstractmethod
@@ -101,7 +107,7 @@ class Model(ABC):
 
     @staticmethod
     @abstractmethod
-    def is_type(obj: Any) -> bool:  # pragma: no cover
+    def is_model_type(obj: Any) -> bool:  # pragma: no cover
         """Check if object is the type of data model class that this model adapter works with."""
         pass
 
@@ -154,7 +160,7 @@ class Model(ABC):
 
 
 model_adapter_registry: Dict[str, Type[Model]] = {}
-"""Registry of concrete [`Model`][erdantic.base.model] adapter subclasses. A concrete `Model`
+"""Registry of concrete [`Model`][erdantic.base.Model] adapter subclasses. A concrete `Model`
 subclass must be registered for it to be available to the diagram creation workflow."""
 
 

--- a/erdantic/base.py
+++ b/erdantic/base.py
@@ -8,7 +8,7 @@ from erdantic.typing import Final, repr_type, repr_type_with_mro
 _row_template = """<tr><td>{name}</td><td port="{name}">{type_name}</td></tr>"""
 
 
-FT = TypeVar("FT", bound=Any)
+FT = TypeVar("FT", bound=Any, covariant=True)
 """Bounded type variable for a field object adapted by adapter class
 [`Field`][erdantic.base.Field]."""
 
@@ -84,7 +84,7 @@ _table_template = """
 """
 
 
-MT = TypeVar("MT", bound=Any)
+MT = TypeVar("MT", bound=type, covariant=True)
 """Bounded type variable for a data model class adapted by adapter class
 [`Model`][erdantic.base.Model]."""
 

--- a/erdantic/base.py
+++ b/erdantic/base.py
@@ -1,10 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Type
 
 from erdantic.typing import repr_type
-
-if TYPE_CHECKING:
-    from erdantic.erd import EntityRelationshipDiagram  # pragma: no cover
 
 
 _row_template = """<tr><td>{name}</td><td port="{name}">{type_name}</td></tr>"""
@@ -127,27 +124,27 @@ class Model(ABC):
         return self.name
 
 
-class DiagramFactory(ABC):
+class Adapter(ABC):
     @staticmethod
     @abstractmethod
-    def is_type(model: type) -> bool:  # pragma: no cover
+    def is_type(obj: Any) -> bool:  # pragma: no cover
         pass
 
-    @staticmethod
+    @property
     @abstractmethod
-    def create(*models: type) -> "EntityRelationshipDiagram":  # pragma: no cover
+    def model_class(self) -> Type[Model]:  # pragma: no cover
         pass
 
 
-factory_registry: Dict[str, DiagramFactory] = {}
+adapter_registry: Dict[str, Adapter] = {}
 
 
-def register_factory(type_name: str) -> Callable[[type], type]:
+def register_adapter(type_name: str) -> Callable[[type], type]:
     def decorator(cls: type) -> type:
-        global factory_registry
-        if not issubclass(cls, DiagramFactory):
-            raise ValueError("Only subclasses of DiagramFactory can be registered.")
-        factory_registry[type_name] = cls()  # Verify completeness by instantiating
+        global adapter_registry
+        if not issubclass(cls, Adapter):
+            raise ValueError("Only subclasses of Adapter can be registered.")
+        adapter_registry[type_name] = cls()  # Verify completeness by instantiating
         return cls
 
     return decorator

--- a/erdantic/base.py
+++ b/erdantic/base.py
@@ -189,7 +189,8 @@ def register_model_adapter(type_name: str) -> Callable[[Type[Model]], Type[Model
         type_name (str): Key used to identify concrete `Model` adapter subclass
 
     Returns:
-        Callable[[type], type]: A registration decorator for a concrete `Model` adapter subclass
+        Callable[[Type[Model]], Type[Model]]: A registration decorator for a concrete `Model`
+            adapter subclass
     """
 
     def decorator(cls: type) -> type:

--- a/erdantic/cli.py
+++ b/erdantic/cli.py
@@ -34,7 +34,7 @@ def main(
         help=(
             "One or more full dotted paths to data model classes to include in diagram, "
             "e.g., 'erdantic.examples.pydantic.Party'. Only the root models of composition trees "
-            "is needed; erdantic will search for component classes."
+            "are needed; erdantic will traverse the composition tree to find component classes."
         ),
     ),
     out: Path = typer.Option(..., "--out", "-o", help="Output filename."),
@@ -74,7 +74,7 @@ def main(
         typer.echo(diagram.to_dot())
     else:
         if out.exists() and no_overwrite:
-            typer.echo(f"{out} already exists and you specified --no-overwrite.")
+            typer.echo(f"{out} already exists, and you specified --no-overwrite.")
             raise typer.Exit(code=1)
         diagram.draw(out)
         typer.echo(f"Rendered diagram to {out}")

--- a/erdantic/dataclasses.py
+++ b/erdantic/dataclasses.py
@@ -7,13 +7,11 @@ from erdantic.base import Field, Model, register_model_adapter
 from erdantic.typing import get_args, get_origin
 
 
-class DataClassField(Field):
-    field: dataclasses.Field
-
-    def __init__(self, field: Any):
+class DataClassField(Field[dataclasses.Field]):
+    def __init__(self, field: dataclasses.Field):
         if not isinstance(field, dataclasses.Field):
             raise ValueError(f"field must be of type dataclasses.Field. Got: {type(field)}")
-        self.field = field
+        super().__init__(field=field)
 
     @property
     def name(self) -> str:
@@ -36,16 +34,14 @@ class DataClassField(Field):
 
 
 @register_model_adapter("dataclasses")
-class DataClassModel(Model):
-    model: type
-
-    def __init__(self, model: Any):
-        if not self.is_type(model):
+class DataClassModel(Model[type]):
+    def __init__(self, model: type):
+        if not self.is_model_type(model):
             raise ValueError(f"Argument model must be a dataclass: {repr(model)}")
-        self.model = model
+        super().__init__(model=model)
 
     @staticmethod
-    def is_type(obj: Any) -> bool:
+    def is_model_type(obj: Any) -> bool:
         return isinstance(obj, type) and dataclasses.is_dataclass(obj)
 
     @property

--- a/erdantic/dataclasses.py
+++ b/erdantic/dataclasses.py
@@ -1,6 +1,5 @@
 import collections.abc
 import dataclasses
-import inspect
 from typing import Any, List, Union
 
 
@@ -9,23 +8,20 @@ from erdantic.typing import get_args, get_origin
 
 
 class DataClassField(Field):
-    dataclass_field: dataclasses.Field
+    field: dataclasses.Field
 
-    def __init__(self, dataclass_field: dataclasses.Field):
-        if not isinstance(dataclass_field, dataclasses.Field):
-            raise ValueError(
-                "dataclass_field must be of type dataclasses.Field. "
-                f"Got: {type(dataclass_field)}"
-            )
-        self.dataclass_field = dataclass_field
+    def __init__(self, field: Any):
+        if not isinstance(field, dataclasses.Field):
+            raise ValueError(f"field must be of type dataclasses.Field. Got: {type(field)}")
+        self.field = field
 
     @property
     def name(self) -> str:
-        return self.dataclass_field.name
+        return self.field.name
 
     @property
     def type_obj(self) -> type:
-        return self.dataclass_field.type
+        return self.field.type
 
     def is_many(self) -> bool:
         origin = get_origin(self.type_obj)
@@ -38,38 +34,20 @@ class DataClassField(Field):
     def is_nullable(self) -> bool:
         return get_origin(self.type_obj) is Union and type(None) in get_args(self.type_obj)
 
-    def __hash__(self) -> int:
-        return id(self.dataclass_field)
-
 
 @register_model_adapter("dataclasses")
 class DataClassModel(Model):
-    dataclass: type
+    model: type
 
-    def __init__(self, dataclass: type):
-        if not self.is_type(dataclass):
-            raise ValueError(f"Argument dataclass must be a dataclass. Got {dataclass}")
-        self.dataclass = dataclass
+    def __init__(self, model: Any):
+        if not self.is_type(model):
+            raise ValueError(f"Argument model must be a dataclass: {repr(model)}")
+        self.model = model
 
     @staticmethod
     def is_type(obj: Any) -> bool:
         return isinstance(obj, type) and dataclasses.is_dataclass(obj)
 
     @property
-    def name(self) -> str:
-        return self.dataclass.__name__
-
-    @property
     def fields(self) -> List[Field]:
-        return [DataClassField(dataclass_field=f) for f in dataclasses.fields(self.dataclass)]
-
-    @property
-    def docstring(self) -> str:
-        out = f"{self.dataclass.__module__}.{self.name}"
-        docstring = inspect.getdoc(self.dataclass)
-        if docstring:
-            out += "\n\n" + docstring
-        return out
-
-    def __hash__(self) -> int:
-        return id(self.dataclass)
+        return [DataClassField(field=f) for f in dataclasses.fields(self.model)]

--- a/erdantic/dataclasses.py
+++ b/erdantic/dataclasses.py
@@ -8,6 +8,13 @@ from erdantic.typing import get_args, get_origin
 
 
 class DataClassField(Field[dataclasses.Field]):
+    """Concrete field adapter class for dataclass fields.
+
+    Attributes:
+        field (dataclasses.Field): The dataclass field instance that is associated with this
+            adapter instance
+    """
+
     def __init__(self, field: dataclasses.Field):
         if not isinstance(field, dataclasses.Field):
             raise ValueError(f"field must be of type dataclasses.Field. Got: {type(field)}")
@@ -35,6 +42,13 @@ class DataClassField(Field[dataclasses.Field]):
 
 @register_model_adapter("dataclasses")
 class DataClassModel(Model[type]):
+    """Concrete model adapter class for a
+    [`dataclasses` module](https://docs.python.org/3/library/dataclasses.html) dataclass.
+
+    Attributes:
+        model (type): The dataclass that is associated with this adapter instance
+    """
+
     def __init__(self, model: type):
         if not self.is_model_type(model):
             raise ValueError(f"Argument model must be a dataclass: {repr(model)}")

--- a/erdantic/dataclasses.py
+++ b/erdantic/dataclasses.py
@@ -1,10 +1,10 @@
 import collections.abc
 import dataclasses
 import inspect
-from typing import Any, List, Type, Union
+from typing import Any, List, Union
 
 
-from erdantic.base import Adapter, Field, Model, register_adapter
+from erdantic.base import Field, Model, register_model_adapter
 from erdantic.typing import get_args, get_origin
 
 
@@ -42,13 +42,18 @@ class DataClassField(Field):
         return id(self.dataclass_field)
 
 
+@register_model_adapter("dataclasses")
 class DataClassModel(Model):
     dataclass: type
 
     def __init__(self, dataclass: type):
-        if not DataClassAdapter.is_type(dataclass):
+        if not self.is_type(dataclass):
             raise ValueError(f"Argument dataclass must be a dataclass. Got {dataclass}")
         self.dataclass = dataclass
+
+    @staticmethod
+    def is_type(obj: Any) -> bool:
+        return isinstance(obj, type) and dataclasses.is_dataclass(obj)
 
     @property
     def name(self) -> str:
@@ -68,14 +73,3 @@ class DataClassModel(Model):
 
     def __hash__(self) -> int:
         return id(self.dataclass)
-
-
-@register_adapter("dataclasses")
-class DataClassAdapter(Adapter):
-    @staticmethod
-    def is_type(obj: Any) -> bool:
-        return isinstance(obj, type) and dataclasses.is_dataclass(obj)
-
-    @property
-    def model_class(self) -> Type[Model]:
-        return DataClassModel

--- a/erdantic/erd.py
+++ b/erdantic/erd.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, List, Set, Tuple, Union
+from typing import Any, List, Set, Union
 
 import pygraphviz as pgv
 

--- a/erdantic/erd.py
+++ b/erdantic/erd.py
@@ -100,7 +100,7 @@ class EntityRelationshipDiagram:
         instance for diagram.
 
         Returns:
-            pgv.AGraph: graph object for diagram
+            pygraphviz.AGraph: graph object for diagram
         """
         g = pgv.AGraph(
             directed=True,
@@ -185,17 +185,17 @@ def create(*models: type) -> EntityRelationshipDiagram:
 
 
 def adapt_model(obj: Any) -> Model:
-    """Dispatch object to appropriate concrete Model adapter class and return instantiated concrete
-    Model subclass instance.
+    """Dispatch object to appropriate concrete [`Model`][erdantic.base.Model] adapter subclass and
+    return instantiated adapter instance.
 
     Args:
-        obj (Any): Input raw data model class to adapt
+        obj (Any): Data model class to adapt
 
     Raises:
         UnknownModelTypeError: If obj does not match registered Model adapter classes
 
     Returns:
-        Model: Instantiated concrete Model subclass instance
+        Model: Instantiated concrete `Model` subclass instance
     """
     for model_adapter in model_adapter_registry.values():
         if model_adapter.is_model_type(obj):

--- a/erdantic/erd.py
+++ b/erdantic/erd.py
@@ -198,7 +198,7 @@ def adapt_model(obj: Any) -> Model:
         Model: Instantiated concrete Model subclass instance
     """
     for model_adapter in model_adapter_registry.values():
-        if model_adapter.is_type(obj):
+        if model_adapter.is_model_type(obj):
             return model_adapter(obj)
     raise UnknownModelTypeError(model=obj)
 

--- a/erdantic/erd.py
+++ b/erdantic/erd.py
@@ -65,10 +65,6 @@ class Edge:
         other_key = (other.source, other.source.fields.index(other.source_field), other.target)
         return self_key < other_key
 
-    def __sort_key__(self) -> Tuple[str, int]:
-        """Key for sorting against other Edge instances."""
-        return (self.source.name, self.source.fields.index(self.source_field))
-
 
 class EntityRelationshipDiagram:
     """Class for entity relationship diagram.

--- a/erdantic/erd.py
+++ b/erdantic/erd.py
@@ -111,12 +111,12 @@ class EntityRelationshipDiagram:
         g.node_attr["shape"] = "plain"
         for model in self.models:
             g.add_node(
-                model.name, label=model.dot_label(), tooltip=model.docstring.replace("\n", "&#xA;")
+                model.id, label=model.dot_label(), tooltip=model.docstring.replace("\n", "&#xA;")
             )
         for edge in self.edges:
             g.add_edge(
-                edge.source.name,
-                edge.target.name,
+                edge.source.id,
+                edge.target.id,
                 tailport=f"{edge.source_field.name}:e",
                 headport="_root:w",
                 arrowhead=edge.dot_arrowhead(),

--- a/erdantic/errors.py
+++ b/erdantic/errors.py
@@ -1,37 +1,13 @@
 from typing import Optional
 
 
-class ModelTypeMismatchError(ValueError):
-    """Raised when multiple models are given but they do not all match the detected type of the
-    first model.
-    """
-
-    def __init__(
-        self,
-        mismatched_model: type,
-        first_model: type,
-        expected: str,
-        message: Optional[str] = None,
-    ):
-        if message is None:
-            message = (
-                f"Additional model does not match detected type of first model. "
-                f"Expected: {expected}; "
-                f"Mismatched model MRO: {mismatched_model.__mro__}"
-            )
-        self.mismatched_model = mismatched_model
-        self.first_model = first_model
-        self.expected = expected
-        self.message = message
-        super().__init__(message)
-
-
 class UnknownModelTypeError(ValueError):
     """Raised when a given model does not match known supported class types."""
 
     def __init__(self, model: type, message: Optional[str] = None):
         if message is None:
-            message = f"Given model does not match any supported types. Model MRO: {model.__mro__}"
+            display = getattr(model, "__mro__", str(model))
+            message = f"Given model does not match any supported types. Model MRO: {display}"
         self.model = model
         self.message = message
         super().__init__(message)

--- a/erdantic/pydantic.py
+++ b/erdantic/pydantic.py
@@ -8,6 +8,13 @@ from erdantic.typing import repr_type_with_mro
 
 
 class PydanticField(Field[pydantic.fields.ModelField]):
+    """Concrete field adapter class for Pydantic fields.
+
+    Attributes:
+        field (pydantic.fields.ModelField): The Pydantic field object that is associated with this
+            adapter instance
+    """
+
     def __init__(self, field: pydantic.fields.ModelField):
         if not isinstance(field, pydantic.fields.ModelField):
             raise ValueError(
@@ -32,6 +39,14 @@ class PydanticField(Field[pydantic.fields.ModelField]):
 
 @register_model_adapter("pydantic")
 class PydanticModel(Model[Type[pydantic.BaseModel]]):
+    """Concrete model adapter class for a Pydantic
+    [`BaseModel`](https://pydantic-docs.helpmanual.io/usage/models/).
+
+    Attributes:
+        model (Type[pydantic.BaseModel]): The Pydantic model class that is associated with this
+            adapter instance
+    """
+
     def __init__(self, model: Type[pydantic.BaseModel]):
         if not self.is_model_type(model):
             raise ValueError(

--- a/erdantic/pydantic.py
+++ b/erdantic/pydantic.py
@@ -7,16 +7,13 @@ from erdantic.base import Field, Model, register_model_adapter
 from erdantic.typing import repr_type_with_mro
 
 
-class PydanticField(Field):
-
-    field: pydantic.fields.ModelField
-
-    def __init__(self, field: Any):
+class PydanticField(Field[pydantic.fields.ModelField]):
+    def __init__(self, field: pydantic.fields.ModelField):
         if not isinstance(field, pydantic.fields.ModelField):
             raise ValueError(
                 f"field must be of type pydantic.fields.ModelField. Got: {type(field)}"
             )
-        self.field = field
+        super().__init__(field=field)
 
     @property
     def name(self) -> str:
@@ -34,19 +31,17 @@ class PydanticField(Field):
 
 
 @register_model_adapter("pydantic")
-class PydanticModel(Model):
-    model: Type[pydantic.BaseModel]
-
-    def __init__(self, model: Any):
-        if not self.is_type(model):
+class PydanticModel(Model[Type[pydantic.BaseModel]]):
+    def __init__(self, model: Type[pydantic.BaseModel]):
+        if not self.is_model_type(model):
             raise ValueError(
                 "Argument model must be a subclass of pydantic.BaseModel. "
                 f"Got {repr_type_with_mro(model)}"
             )
-        self.model = model
+        super().__init__(model=model)
 
     @staticmethod
-    def is_type(obj: Any) -> bool:
+    def is_model_type(obj: Any) -> bool:
         return isinstance(obj, type) and issubclass(obj, pydantic.BaseModel)
 
     @property

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -91,14 +91,13 @@ def repr_enum(tp: Type[Enum]) -> str:
     return f"{tp.__name__}({', '.join(b.__name__ for b in depth1_bases)})"
 
 
-def full_name(tp: type) -> str:
-    """Full dotted name of a type."""
-    module = tp.__module__.replace("builtins", "")
-    return f"{module}.{tp.__name__}"
-
-
 def repr_type_with_mro(obj: Any) -> str:
     """Return MRO of object if it has one. Otherwise return its repr."""
+
+    def _full_name(tp: type) -> str:
+        module = tp.__module__.replace("builtins", "")
+        return f"{module}.{tp.__qualname__}"
+
     if hasattr(obj, "__mro__"):
-        return f"<mro ({', '.join(full_name(m) for m in obj.__mro__)})>"
+        return f"<mro ({', '.join(_full_name(m) for m in obj.__mro__)})>"
     return repr(obj)

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -95,9 +95,10 @@ def repr_type_with_mro(obj: Any) -> str:
     """Return MRO of object if it has one. Otherwise return its repr."""
 
     def _full_name(tp: type) -> str:
-        module = tp.__module__.replace("builtins", "")
-        return f"{module}.{tp.__qualname__}"
+        module = tp.__module__
+        return f"{module}.{tp.__qualname__}".replace("builtins.", "")
 
     if hasattr(obj, "__mro__"):
-        return f"<mro ({', '.join(_full_name(m) for m in obj.__mro__)})>"
+        mro = ", ".join(_full_name(m) for m in obj.__mro__)
+        return f"<mro ({mro})>"
     return repr(obj)

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -9,6 +9,11 @@ try:
 except ImportError:
     from typing import GenericMeta as GenericAlias  # type: ignore # Python 3.6
 
+try:
+    from typing import Final  # type: ignore # Python 3.8+
+except ImportError:
+    from typing_extensions import Final  # type: ignore # noqa: F401 # Python 3.6-3.7
+
 
 def _get_args(tp):
     """Backport of typing.get_args for Python 3.6"""

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Type, Union
+from typing import Any, List, Type, Union
 
 try:
     from typing import _GenericAlias as GenericAlias  # type: ignore # Python 3.7+
@@ -29,6 +29,12 @@ except ImportError:
         # Python 3.6
         get_args = _get_args
         get_origin = _get_origin
+
+
+def get_depth1_bases(tp: type) -> List[type]:
+    """Returns depth-1 base classes of a type."""
+    bases_of_bases = {bb for b in tp.__mro__[1:] for bb in b.__mro__[1:]}
+    return [b for b in tp.__mro__[1:] if b not in bases_of_bases]
 
 
 def get_recursive_args(tp: Union[type, GenericAlias]) -> List[type]:
@@ -80,7 +86,14 @@ def repr_enum(tp: Type[Enum]) -> str:
     return f"{tp.__name__}({', '.join(b.__name__ for b in depth1_bases)})"
 
 
-def get_depth1_bases(tp: type) -> List[type]:
-    """Returns depth-1 base classes of a type."""
-    bases_of_bases = {bb for b in tp.__mro__[1:] for bb in b.__mro__[1:]}
-    return [b for b in tp.__mro__[1:] if b not in bases_of_bases]
+def full_name(tp: type) -> str:
+    """Full dotted name of a type."""
+    module = tp.__module__.replace("builtins", "")
+    return f"{module}.{tp.__name__}"
+
+
+def repr_type_with_mro(obj: Any) -> str:
+    """Return MRO of object if it has one. Otherwise return its repr."""
+    if hasattr(obj, "__mro__"):
+        return f"<mro ({', '.join(full_name(m) for m in obj.__mro__)})>"
+    return repr(obj)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,7 +2,7 @@ import pytest
 
 import erdantic as erd
 from erdantic.examples.pydantic import Party
-from erdantic.base import Adapter, Field, Model, register_adapter
+from erdantic.base import Field, Model, register_model_adapter
 
 
 def test_abstract_field_instatiation():
@@ -15,20 +15,13 @@ def test_abstract_model_instantiation():
         Model()
 
 
-def test_adapter_registration():
-    # Incomplete implementation
-    class IncompleteAdapter(Adapter):
-        pass
-
-    with pytest.raises(TypeError, match=r"Can't instantiate abstract class"):
-        register_adapter("incomplete")(IncompleteAdapter)
-
+def test_model_adapter_registration_error():
     # Not a subclass
-    class UsbAdapter:
+    class ModelAirplane:
         pass
 
-    with pytest.raises(ValueError, match=r"Only subclasses of Adapter can be registered"):
-        register_adapter("usb")(UsbAdapter)
+    with pytest.raises(ValueError, match=r"Only subclasses of Model can be registered"):
+        register_model_adapter("airplane")(ModelAirplane)
 
 
 def test_repr():

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,7 +2,7 @@ import pytest
 
 import erdantic as erd
 from erdantic.examples.pydantic import Party
-from erdantic.base import DiagramFactory, Field, Model, register_factory
+from erdantic.base import Adapter, Field, Model, register_adapter
 
 
 def test_abstract_field_instatiation():
@@ -15,20 +15,20 @@ def test_abstract_model_instantiation():
         Model()
 
 
-def test_diagram_factory_registration():
+def test_adapter_registration():
     # Incomplete implementation
-    class IncompleteDiagramFactory(DiagramFactory):
+    class IncompleteAdapter(Adapter):
         pass
 
     with pytest.raises(TypeError, match=r"Can't instantiate abstract class"):
-        register_factory("incomplete")(IncompleteDiagramFactory)
+        register_adapter("incomplete")(IncompleteAdapter)
 
     # Not a subclass
-    class DiagramFarm:
+    class UsbAdapter:
         pass
 
-    with pytest.raises(ValueError, match=r"Only subclasses of DiagramFactory can be registered"):
-        register_factory("potato")(DiagramFarm)
+    with pytest.raises(ValueError, match=r"Only subclasses of Adapter can be registered"):
+        register_adapter("usb")(UsbAdapter)
 
 
 def test_repr():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+from difflib import SequenceMatcher
 import filecmp
 import subprocess
 
@@ -81,7 +82,9 @@ def test_dot(tmp_path):
     )
     assert result.returncode == 0
     assert not path.exists()  # -o is ignored and no file created
-    assert erd.to_dot(Party).strip() == result.stdout.strip()
+    # subprocess won't have the same Model id values so we do an approximate match
+    s = SequenceMatcher(None, erd.to_dot(Party).strip(), result.stdout.strip())
+    assert s.ratio() > 0.9
 
 
 def test_help():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-from difflib import SequenceMatcher
 import filecmp
 import subprocess
 
@@ -82,9 +81,7 @@ def test_dot(tmp_path):
     )
     assert result.returncode == 0
     assert not path.exists()  # -o is ignored and no file created
-    # subprocess won't have the same Model id values so we do an approximate match
-    s = SequenceMatcher(None, erd.to_dot(Party).strip(), result.stdout.strip())
-    assert s.ratio() > 0.9
+    assert erd.to_dot(Party).strip() == result.stdout.strip()
 
 
 def test_help():

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -5,30 +5,23 @@ import textwrap
 from typing import Dict, Tuple
 
 import erdantic as erd
-from erdantic.dataclasses import DataClassModel, DataClassField, DataClassDiagramFactory
+from erdantic.dataclasses import DataClassAdapter, DataClassField, DataClassModel
 from erdantic.examples.dataclasses import Adventurer, Party, Quest, QuestGiver
 
 
 def test_is_type():
-    factory = DataClassDiagramFactory()
+    adapter = DataClassAdapter()
 
     @dataclasses.dataclass
     class IsADataClass:
         attr: str
 
-    assert factory.is_type(IsADataClass)
+    assert adapter.is_type(IsADataClass)
 
     class NotADataClass:
         attr: str
 
-    assert not factory.is_type(NotADataClass)
-
-
-def test_create_diagram():
-    factory = DataClassDiagramFactory()
-    diagram = factory.create(Party)
-    assert isinstance(diagram, erd.EntityRelationshipDiagram)
-    assert diagram == erd.create(Party)
+    assert not adapter.is_type(NotADataClass)
 
 
 def test_model_graph_search():
@@ -103,8 +96,8 @@ def test_to_dot():
 def test_registration():
     script = textwrap.dedent(
         """\
-        from erdantic.base import factory_registry;
-        assert "dataclasses" in factory_registry;
+        from erdantic.base import adapter_registry;
+        assert "dataclasses" in adapter_registry;
         """
     ).replace("\n", "")
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -9,17 +9,17 @@ from erdantic.dataclasses import DataClassField, DataClassModel
 from erdantic.examples.dataclasses import Adventurer, Party, Quest, QuestGiver
 
 
-def test_is_type():
+def test_is_model_type():
     @dataclasses.dataclass
     class IsADataClass:
         attr: str
 
-    assert DataClassModel.is_type(IsADataClass)
+    assert DataClassModel.is_model_type(IsADataClass)
 
     class NotADataClass:
         attr: str
 
-    assert not DataClassModel.is_type(NotADataClass)
+    assert not DataClassModel.is_model_type(NotADataClass)
 
 
 def test_model_graph_search():

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -5,23 +5,21 @@ import textwrap
 from typing import Dict, Tuple
 
 import erdantic as erd
-from erdantic.dataclasses import DataClassAdapter, DataClassField, DataClassModel
+from erdantic.dataclasses import DataClassField, DataClassModel
 from erdantic.examples.dataclasses import Adventurer, Party, Quest, QuestGiver
 
 
 def test_is_type():
-    adapter = DataClassAdapter()
-
     @dataclasses.dataclass
     class IsADataClass:
         attr: str
 
-    assert adapter.is_type(IsADataClass)
+    assert DataClassModel.is_type(IsADataClass)
 
     class NotADataClass:
         attr: str
 
-    assert not adapter.is_type(NotADataClass)
+    assert not DataClassModel.is_type(NotADataClass)
 
 
 def test_model_graph_search():
@@ -96,8 +94,8 @@ def test_to_dot():
 def test_registration():
     script = textwrap.dedent(
         """\
-        from erdantic.base import adapter_registry;
-        assert "dataclasses" in adapter_registry;
+        from erdantic.base import model_adapter_registry;
+        assert "dataclasses" in model_adapter_registry;
         """
     ).replace("\n", "")
 

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -24,8 +24,8 @@ def test_is_type():
 
 def test_model_graph_search():
     diagram = erd.create(Party)
-    assert {m.dataclass for m in diagram.models} == {Party, Adventurer, Quest, QuestGiver}
-    assert {(e.source.dataclass, e.target.dataclass) for e in diagram.edges} == {
+    assert {m.model for m in diagram.models} == {Party, Adventurer, Quest, QuestGiver}
+    assert {(e.source.model, e.target.model) for e in diagram.edges} == {
         (Party, Adventurer),
         (Party, Quest),
         (Quest, QuestGiver),
@@ -46,8 +46,8 @@ def test_model_graph_search_nested_args():
         inner: Dict[str, Tuple[Inner0, Inner1]]
 
     diagram = erd.create(Outer)
-    assert {m.dataclass for m in diagram.models} == {Outer, Inner0, Inner1}
-    assert {(e.source.dataclass, e.target.dataclass) for e in diagram.edges} == {
+    assert {m.model for m in diagram.models} == {Outer, Inner0, Inner1}
+    assert {(e.source.model, e.target.model) for e in diagram.edges} == {
         (Outer, Inner0),
         (Outer, Inner1),
     }

--- a/tests/test_erd.py
+++ b/tests/test_erd.py
@@ -4,9 +4,8 @@ import pytest
 
 import erdantic as erd
 from erdantic.erd import Edge
-from erdantic.errors import ModelTypeMismatchError, UnknownModelTypeError
+from erdantic.errors import UnknownModelTypeError
 from erdantic.examples.pydantic import Party, Quest
-from erdantic.examples.dataclasses import Adventurer as DataClassAdventurer
 
 
 def test_diagram_comparisons():
@@ -36,18 +35,6 @@ def test_edge_comparisons():
 def test_not_a_type_error():
     with pytest.raises(ValueError, match="Given model is not a type"):
         erd.create(5)
-
-
-def test_model_type_mismatch_error():
-    with pytest.raises(ModelTypeMismatchError) as e_info:
-        erd.create(Party, DataClassAdventurer)
-    e = e_info.value
-    assert e.mismatched_model is DataClassAdventurer
-    assert e.first_model is Party
-    assert e.expected == "pydantic"
-    assert "Additional model does not match detected type of first model" in str(e)
-    assert DataClassAdventurer.__name__ in str(e)
-    assert "pydantic" in str(e)
 
 
 def test_unknown_model_type_error():

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -24,8 +24,8 @@ def test_is_type():
 
 def test_model_graph_search():
     diagram = erd.create(Party)
-    assert {m.pydantic_model for m in diagram.models} == {Party, Adventurer, Quest, QuestGiver}
-    assert {(e.source.pydantic_model, e.target.pydantic_model) for e in diagram.edges} == {
+    assert {m.model for m in diagram.models} == {Party, Adventurer, Quest, QuestGiver}
+    assert {(e.source.model, e.target.model) for e in diagram.edges} == {
         (Party, Adventurer),
         (Party, Quest),
         (Quest, QuestGiver),
@@ -43,8 +43,8 @@ def test_model_graph_search_nested_args():
         inner: Dict[str, Tuple[Inner0, Inner1]]
 
     diagram = erd.create(Outer)
-    assert {m.pydantic_model for m in diagram.models} == {Outer, Inner0, Inner1}
-    assert {(e.source.pydantic_model, e.target.pydantic_model) for e in diagram.edges} == {
+    assert {m.model for m in diagram.models} == {Outer, Inner0, Inner1}
+    assert {(e.source.model, e.target.model) for e in diagram.edges} == {
         (Outer, Inner0),
         (Outer, Inner1),
     }

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -6,22 +6,20 @@ from typing import Dict, Tuple
 from pydantic import BaseModel
 
 import erdantic as erd
-from erdantic.pydantic import PydanticAdapter, PydanticField, PydanticModel
+from erdantic.pydantic import PydanticField, PydanticModel
 from erdantic.examples.pydantic import Adventurer, Party, Quest, QuestGiver
 
 
 def test_is_type():
-    adapter = PydanticAdapter()
-
     class IsAPydanticModel(BaseModel):
         attr: str
 
-    assert adapter.is_type(IsAPydanticModel)
+    assert PydanticModel.is_type(IsAPydanticModel)
 
     class NotAPydanticModel:
         attr: str
 
-    assert not adapter.is_type(NotAPydanticModel)
+    assert not PydanticModel.is_type(NotAPydanticModel)
 
 
 def test_model_graph_search():
@@ -93,8 +91,8 @@ def test_to_dot():
 def test_registration():
     script = textwrap.dedent(
         """\
-        from erdantic.base import adapter_registry;
-        assert "pydantic" in adapter_registry;
+        from erdantic.base import model_adapter_registry;
+        assert "pydantic" in model_adapter_registry;
         """
     ).replace("\n", "")
 

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -6,29 +6,22 @@ from typing import Dict, Tuple
 from pydantic import BaseModel
 
 import erdantic as erd
-from erdantic.pydantic import PydanticDiagramFactory, PydanticField, PydanticModel
+from erdantic.pydantic import PydanticAdapter, PydanticField, PydanticModel
 from erdantic.examples.pydantic import Adventurer, Party, Quest, QuestGiver
 
 
 def test_is_type():
-    factory = PydanticDiagramFactory()
+    adapter = PydanticAdapter()
 
     class IsAPydanticModel(BaseModel):
         attr: str
 
-    assert factory.is_type(IsAPydanticModel)
+    assert adapter.is_type(IsAPydanticModel)
 
     class NotAPydanticModel:
         attr: str
 
-    assert not factory.is_type(NotAPydanticModel)
-
-
-def test_create_diagram():
-    factory = PydanticDiagramFactory()
-    diagram = factory.create(Party)
-    assert isinstance(diagram, erd.EntityRelationshipDiagram)
-    assert diagram == erd.create(Party)
+    assert not adapter.is_type(NotAPydanticModel)
 
 
 def test_model_graph_search():
@@ -100,8 +93,8 @@ def test_to_dot():
 def test_registration():
     script = textwrap.dedent(
         """\
-        from erdantic.base import factory_registry;
-        assert "pydantic" in factory_registry;
+        from erdantic.base import adapter_registry;
+        assert "pydantic" in adapter_registry;
         """
     ).replace("\n", "")
 

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -10,16 +10,16 @@ from erdantic.pydantic import PydanticField, PydanticModel
 from erdantic.examples.pydantic import Adventurer, Party, Quest, QuestGiver
 
 
-def test_is_type():
+def test_is_model_type():
     class IsAPydanticModel(BaseModel):
         attr: str
 
-    assert PydanticModel.is_type(IsAPydanticModel)
+    assert PydanticModel.is_model_type(IsAPydanticModel)
 
     class NotAPydanticModel:
         attr: str
 
-    assert not PydanticModel.is_type(NotAPydanticModel)
+    assert not PydanticModel.is_model_type(NotAPydanticModel)
 
 
 def test_model_graph_search():

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -8,11 +8,12 @@ from erdantic.typing import (
     _get_args,
     _get_origin,
     get_args,
+    get_depth1_bases,
     get_origin,
     get_recursive_args,
     repr_enum,
     repr_type,
-    get_depth1_bases,
+    repr_type_with_mro,
 )
 
 
@@ -100,6 +101,17 @@ if sys.version_info[:2] >= (3, 9):
 def test_repr_type(case):
     tp, expected = case
     assert repr_type(tp) == expected
+
+
+def test_repr_type_with_mro():
+    class FancyInt(int):
+        pass
+
+    assert (
+        repr_type_with_mro(FancyInt)
+        == "<mro (tests.test_typing.test_repr_type_with_mro.<locals>.FancyInt, int, object)>"
+    )
+    assert repr_type_with_mro(FancyInt()) == repr(FancyInt())
 
 
 # Test backports against typing module implementations


### PR DESCRIPTION
- Reduce layers of abstraction for adapting data model frameworks to working with erdantic. Now it's only necessary to implement concrete `Field` and `Model` classes, and the `Model` subclass is registered directly for dispatch.  
- Set up `Field` and `Model` to be covariant on their respective `field` and `model` attributes. This reduces the number of abstract methods necessary and improves code reuse. 
- `EntityRelationshipDiagram` and `create` are set up now to be covariant in models. This takes advantage of concrete `Model` classes and `Field` classes satisfying LSP. This means we can mix data model classes in one diagram. While not expected to be practically used, it simplifies the code paths and reduces amount of error checking needed. 