### PR TITLE
Add versioned docs

### DIFF
--- a/.github/workflows/docs-main.yml
+++ b/.github/workflows/docs-main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build and publish docs on main
+    name: Build docs from main
     runs-on: "ubuntu-latest"
 
     steps:
@@ -30,10 +30,28 @@ jobs:
         run: |
           make docs
 
+      - name: Stage docs on gh-pages
+        working-directory: docs
+        run: |
+          git fetch origin gh-pages --depth=1
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          mike deploy --push ~dev --title=dev
+
+  deploy:
+    name: Deploy docs to Netlify
+    needs: build
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
       - name: Deploy docs to Netlify
         uses: nwtgck/actions-netlify@v1.1
         with:
-          publish-dir: "./docs/site"
+          publish-dir: "./"
           production-deploy: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,13 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Check that versions match
+        id: version
         run: |
-          echo "${{ github.event.release.tag_name }}"
+          echo "Release tag: [${{ github.event.release.tag_name }}]"
           PACKAGE_VERSION=$(python -c "import erdantic; print(erdantic.__version__)")
-          echo $PACKAGE_VERSION
+          echo "Package version: [$PACKAGE_VERSION]"
           [ ${{ github.event.release.tag_name }} == "v$PACKAGE_VERSION" ] || { exit 1; }
+          echo "::set-output name=major_minor_version::v${PACKAGE_VERSION%.*}"
 
       - name: Build package
         run: |
@@ -40,21 +42,6 @@ jobs:
       - name: Build docs
         run: |
           make docs
-
-      - name: Deploy docs to Netlify
-        uses: nwtgck/actions-netlify@v1.1
-        with:
-          publish-dir: "./docs/site"
-          production-deploy: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: false
-          enable-commit-comment: false
-          overwrites-pull-request-comment: false
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 1
 
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.3.0
@@ -70,3 +57,39 @@ jobs:
           user: ${{ secrets.PYPI_PROD_USERNAME }}
           password: ${{ secrets.PYPI_PROD_PASSWORD }}
           skip_existing: false
+
+      - name: Stage docs on gh-pages
+        working-directory: docs
+        run: |
+          git fetch origin gh-pages --depth=1
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          mike deploy --push --update-aliases --no-redirect \
+            ${{ steps.version.outputs.major_minor_version }} \
+            stable \
+            --title=${{ github.event.release.tag_name }}
+
+  deploy-docs:
+    name: Deploy docs to Netlify
+    needs: build
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Deploy docs to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          publish-dir: "./"
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          overwrites-pull-request-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -56,3 +56,7 @@ plugins:
             show_category_heading: true
       watch:
         - erdantic
+
+extra:
+  version:
+    provider: mike

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,9 +4,10 @@ black
 flake8
 jupyterlab
 mdx_truly_sane_lists==1.2
-mkdocs>=1.1
+mike
+mkdocs>=1.2.2
 mkdocs-jupyter
-mkdocs-material
+mkdocs-material>=7.2.6
 mkdocstrings
 mypy
 pytest


### PR DESCRIPTION
Adds versioned docs using [mike](https://github.com/jimporter/mike).

- Merges to main deploy as the `dev` version.
- Releases deploy as `<major>.<minor>` version, overwriting previous versions that have the same major and minor. The default alias `stable` is updated to point at the new release.