### PR TITLE
Pin mkdocstrings>=0.15.2 for compatibility with mkdocs>=1.2.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ mike
 mkdocs>=1.2.2
 mkdocs-jupyter
 mkdocs-material>=7.2.6
-mkdocstrings
+mkdocstrings>=0.15.2
 mypy
 pytest
 pytest-cases


### PR DESCRIPTION
Closes #36 