### PR TITLE
Fix issue when a model has a Literal

### DIFF
--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Type, Union, Literal
+from typing import Any, List, Type, Union
 
 try:
     from typing import _GenericAlias as GenericAlias  # type: ignore # Python 3.7+
@@ -18,6 +18,11 @@ try:
     from typing import ForwardRef  # type: ignore # Python >= 3.7.4
 except ImportError:
     from typing import _ForwardRef as ForwardRef  # type: ignore # Python < 3.7.4
+
+try:
+    from typing import Literal  # Python >= 3.8
+except ImportError:
+    from typing_extensions import Literal  # Python <= 3.7
 
 from erdantic.exceptions import _StringForwardRefError, _UnevaluatedForwardRefError
 

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -22,7 +22,10 @@ except ImportError:
 try:
     from typing import Literal  # type: ignore # Python >= 3.8
 except ImportError:
-    from typing_extensions import Literal  # type: ignore # Python <= 3.7
+    try:
+        from typing_extensions import Literal  # type: ignore # Python ==3.7.*
+    except ImportError:
+        Literal = None  # type: ignore # Python <3.7
 
 from erdantic.exceptions import _StringForwardRefError, _UnevaluatedForwardRefError
 
@@ -67,7 +70,7 @@ def get_recursive_args(tp: Union[type, GenericAlias]) -> List[type]:
                 raise _UnevaluatedForwardRefError(forward_ref=t)
 
         args = get_args(t)
-        is_literal = get_origin(t) is Literal
+        is_literal = Literal is not None and get_origin(t) is Literal
         if is_literal:
             yield Literal
         elif args:

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Type, Union
+from typing import Any, List, Type, Union, Literal
 
 try:
     from typing import _GenericAlias as GenericAlias  # type: ignore # Python 3.7+
@@ -62,7 +62,10 @@ def get_recursive_args(tp: Union[type, GenericAlias]) -> List[type]:
                 raise _UnevaluatedForwardRefError(forward_ref=t)
 
         args = get_args(t)
-        if args:
+        is_literal = get_origin(t) is Literal
+        if is_literal:
+            yield Literal
+        elif args:
             for arg in args:
                 yield from recurse(arg)
         else:

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -20,9 +20,9 @@ except ImportError:
     from typing import _ForwardRef as ForwardRef  # type: ignore # Python < 3.7.4
 
 try:
-    from typing import Literal  # Python >= 3.8
+    from typing import Literal  # type: ignore # Python >= 3.8
 except ImportError:
-    from typing_extensions import Literal  # Python <= 3.7
+    from typing_extensions import Literal  # type: ignore # Python <= 3.7
 
 from erdantic.exceptions import _StringForwardRefError, _UnevaluatedForwardRefError
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -39,7 +39,7 @@ def test_get_recursive_args():
 
     assert get_recursive_args(str) == [str]
     if Literal is not None:
-        assert get_recursive_args(Literal["batman"]) == [Literal]
+        assert get_recursive_args(Literal["batman"]) in [[Literal], [Literal["batman"]]]
 
 
 def test_get_depth1_bases():
@@ -115,14 +115,16 @@ if sys.version_info[:2] >= (3, 9):
         ]
     )
 
-if Literal is not None:
-    repr_type_cases.append((Literal["batman"], "Literal['batman']"))
-
 
 @pytest.mark.parametrize("case", repr_type_cases, ids=[c[1] for c in repr_type_cases])
 def test_repr_type(case):
     tp, expected = case
     assert repr_type(tp) == expected
+
+
+def test_repr_type_literal():
+    tp = Literal["batman"]
+    assert "Literal['batman']" in repr_type(tp)
 
 
 def test_repr_type_with_mro():

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -8,9 +8,12 @@ except ImportError:
     from typing import _ForwardRef as ForwardRef  # type: ignore # Python < 3.7.4
 
 try:
-    from typing import Literal
+    from typing import Literal  # type: ignore # Python >=3.8
 except ImportError:
-    from typing_extensions import Literal
+    try:
+        from typing_extensions import Literal  # type: ignore # Python ==3.7.*
+    except ImportError:
+        Literal = None  # type: ignore # Python <3.7
 
 
 import pytest
@@ -35,7 +38,8 @@ def test_get_recursive_args():
     assert set(args) == {str, int, float, type(None)}
 
     assert get_recursive_args(str) == [str]
-    assert get_recursive_args(Literal["batman"]) == [Literal]
+    if Literal is not None:
+        assert get_recursive_args(Literal["batman"]) == [Literal]
 
 
 def test_get_depth1_bases():
@@ -100,7 +104,6 @@ repr_type_cases = [
     (typing.Any, "Any"),
     (typing.Dict[str, typing.Any], "Dict[str, Any]"),
     (ForwardRef("MyClass"), "MyClass"),
-    (Literal["batman"], "Literal['batman']"),
 ]
 
 if sys.version_info[:2] >= (3, 9):
@@ -111,6 +114,9 @@ if sys.version_info[:2] >= (3, 9):
             (dict[str, list[int]], "dict[str, list[int]]"),
         ]
     )
+
+if Literal is not None:
+    repr_type_cases.append((Literal["batman"], "Literal['batman']"))
 
 
 @pytest.mark.parametrize("case", repr_type_cases, ids=[c[1] for c in repr_type_cases])

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -7,6 +7,11 @@ try:
 except ImportError:
     from typing import _ForwardRef as ForwardRef  # type: ignore # Python < 3.7.4
 
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 
 import pytest
 
@@ -30,6 +35,7 @@ def test_get_recursive_args():
     assert set(args) == {str, int, float, type(None)}
 
     assert get_recursive_args(str) == [str]
+    assert get_recursive_args(Literal["batman"]) == [Literal]
 
 
 def test_get_depth1_bases():
@@ -94,6 +100,7 @@ repr_type_cases = [
     (typing.Any, "Any"),
     (typing.Dict[str, typing.Any], "Dict[str, Any]"),
     (ForwardRef("MyClass"), "MyClass"),
+    (Literal["batman"], "Literal['batman']"),
 ]
 
 if sys.version_info[:2] >= (3, 9):


### PR DESCRIPTION
A `Literal` is special in that the argument to the literal is the actual
collection of exact values that are permissible to that field.

-----------

Bug description.  Start with a file named `erdbug.py` with the following contents:

```python
from pydantic import BaseModel
from typing import Literal

class Species(BaseModel):
    name: str

class PigmentedFlower(BaseModel):
    color: str
    species: Species

class BlackFlower(PigmentedFlower):
    color: Literal["black"] = "black"

class BlueFlower(PigmentedFlower):
    color: Literal["blue"] = "blue"
```

If we run the following command:

```
$ PYTHONPATH=`pwd` erdantic -o diagram.png erdbug.PigmentedFlower erdbug.BlackFlower erdbug.BlueFlower erdbug.Species
```

We get the following error:

```
Traceback (most recent call last):
  File "/Applications/Anaconda/anaconda3/envs/foundry-dev/bin/erdantic", line 33, in <module>
    sys.exit(load_entry_point('erdantic', 'console_scripts', 'erdantic')())
  File "/Applications/Anaconda/anaconda3/envs/foundry-dev/lib/python3.8/site-packages/typer/main.py", line 214, in __call__
    return get_command(self)(*args, **kwargs)
  File "/Applications/Anaconda/anaconda3/envs/foundry-dev/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Applications/Anaconda/anaconda3/envs/foundry-dev/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Applications/Anaconda/anaconda3/envs/foundry-dev/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Applications/Anaconda/anaconda3/envs/foundry-dev/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Applications/Anaconda/anaconda3/envs/foundry-dev/lib/python3.8/site-packages/typer/main.py", line 500, in wrapper
    return callback(**use_params)  # type: ignore
  File "/Users/swails/src/entos/erdantic/erdantic/cli.py", line 87, in main
    diagram = create(*model_classes, termini=termini_classes)
  File "/Users/swails/src/entos/erdantic/erdantic/erd.py", line 192, in create
    search_composition_graph(model=model, seen_models=seen_models, seen_edges=seen_edges)
  File "/Users/swails/src/entos/erdantic/erdantic/erd.py", line 245, in search_composition_graph
    raise StringForwardRefError(
erdantic.exceptions.StringForwardRefError: Forward reference 'black' for field 'color' on model 'BlackFlower' is a string literal and not a typing.ForwardRef object. erdantic is unable to handle forward references that aren't transformed into typing.ForwardRef. Declare explicitly with 'typing.ForwardRef("black", is_argument=False)'.
```

The problem is that it's trying to evaluate the value passed to the `Literal` as a forward reference if it's a string, when in reality `Literal` is a special typing utility to indicate that the variable carries a specific value.


After this PR, the following diagram is generated:

![diagram](https://user-images.githubusercontent.com/779022/162100254-060e0dde-1fc4-4978-ac43-ce0706bdfffb.png)