### PR TITLE
Add python extra for mkdocstrings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,8 @@
 # erdantic Changelog
 
-## v0.5.0 (unreleased)
+## v0.5.0 (2022-06-03)
 
-- Drop support for Python 3.6. ([Issue #51](https://github.com/drivendataorg/erdantic/issues/51))
+- Removed support for Python 3.6. ([Issue #51](https://github.com/drivendataorg/erdantic/issues/51), [PR #56](https://github.com/drivendataorg/erdantic/pull/56))
 
 ## v0.4.1 (2022-04-08)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # erdantic Changelog
 
+## v0.5.0 (unreleased)
+
+- Drop support for Python 3.6. ([Issue #51](https://github.com/drivendataorg/erdantic/issues/51))
+
 ## v0.4.1 (2022-04-08)
 
 - Fixed error when rendering a data model that has field using `typing.Literal`. ([PR #49](https://github.com/drivendataorg/erdantic/pull/49))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ mike
 mkdocs>=1.2.2
 mkdocs-jupyter
 mkdocs-material>=7.2.6
-mkdocstrings>=0.15.2
+mkdocstrings[python]>=0.19.0
 mypy
 pytest
 pytest-cases

--- a/setup.py
+++ b/setup.py
@@ -25,17 +25,17 @@ requirements = load_requirements(Path(__file__).parent / "requirements.txt")
 setup(
     author="DrivenData",
     author_email="info@drivendata.org",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Code Generators",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     description=("Entity relationship diagrams for Python data model classes like Pydantic."),
     entry_points={"console_scripts": ["erdantic=erdantic.cli:app"]},
@@ -51,5 +51,5 @@ setup(
         "Source Code": "https://github.com/drivendataorg/erdantic",
     },
     url="https://github.com/drivendataorg/erdantic",
-    version="0.4.1",
+    version="0.5.0",
 )


### PR DESCRIPTION
`mkdocstrings` 0.19.0 requires that the python extra be explicitly installed.

Also, to make tests pass with this version, we needed to do #51 as well and drop support for Python 3.6.

Closes #55 
Closes #51 