### PR TITLE
Clean up old Python 3.6 code paths

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7.3", 3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7.3", 3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7.1", 3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7.1", 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/docs/forward-references.md
+++ b/docs/docs/forward-references.md
@@ -86,9 +86,9 @@ Forward references must be evaluated along with the right namespace in order to 
 
 ## Untransformed String Forward References
 
-Under the hood, forward references usually—but not always—get converted from a string to a `typing.ForwardRef` (or in Python <3.7.4, `typing._ForwardRef`) instances. These objects track metadata about the type annotation, including what they get evaluated to.
+Under the hood, forward references usually—but not always—get converted from a string to a `typing.ForwardRef` instances. These objects track metadata about the type annotation, including what they get evaluated to.
 
-Unfortunately, sometimes the annotations remain as unconverted strings, and erdantic is unable to handle those cases. In such cases, erdantic will error with a `StringForwardRefError`. To work around that, you can explicitly declare those annotations with `typing.ForwardRef` (or `typing._ForwardRef` for Python <3.7.4).
+Unfortunately, sometimes the annotations remain as unconverted strings, and erdantic is unable to handle those cases. In such cases, erdantic will error with a `StringForwardRefError`. To work around that, you can explicitly declare those annotations with `typing.ForwardRef`.
 
 === "Pydantic"
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -51,7 +51,7 @@ plugins:
             inherited_members: true
           rendering:
             show_root_heading: false
-            show_root_toc_entry: false
+            show_root_toc_entry: true
             show_root_full_path: false
             show_if_no_docstring: true
             show_signature_annotations: true
@@ -59,9 +59,10 @@ plugins:
             heading_level: 2
             group_by_category: true
             show_category_heading: true
-      watch:
-        - erdantic
 
 extra:
   version:
     provider: mike
+
+watch:
+  - ../erdantic

--- a/erdantic/exceptions.py
+++ b/erdantic/exceptions.py
@@ -1,11 +1,7 @@
 import sys
 from typing import Optional, TYPE_CHECKING
 
-try:
-    from typing import ForwardRef  # type: ignore # Python >= 3.7.4
-except ImportError:
-    from typing import _ForwardRef as ForwardRef  # type: ignore # Python < 3.7.4
-
+from typing import ForwardRef  # docs claim Python >= 3.7.4 but actually it's in Python 3.7.0+
 
 if TYPE_CHECKING:
     from erdantic.base import Model, Field

--- a/erdantic/exceptions.py
+++ b/erdantic/exceptions.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Optional, TYPE_CHECKING
 
 from typing import ForwardRef  # docs claim Python >= 3.7.4 but actually it's in Python 3.7.0+

--- a/erdantic/exceptions.py
+++ b/erdantic/exceptions.py
@@ -38,9 +38,6 @@ class StringForwardRefError(ErdanticException):
             "forward references that aren't transformed into typing.ForwardRef. Declare "
             f"explicitly with 'typing.ForwardRef(\"{forward_ref}\", is_argument=False)'."
         )
-        if sys.version_info[:3] < (3, 7, 4):
-            message = message.replace("typing.ForwardRef", "typing._ForwardRef")
-
         super().__init__(message)
 
 

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -1,9 +1,9 @@
 from enum import Enum
 from typing import Any, List, Type, Union
 
-from typing import _GenericAlias as GenericAlias  # type: ignore # Python 3.7+
 # Note Python 3.9's types.GenericAlias != typing._GenericAlias
 # We still want typing._GenericAlias for typing module's deprecated capital generic aliases
+from typing import _GenericAlias as GenericAlias  # type: ignore # Python 3.7+
 
 try:
     from typing import Final  # type: ignore # Python 3.8+

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -76,9 +76,6 @@ def repr_type(tp: Union[type, GenericAlias]) -> str:
         # If generic alias from typing module, back out its name
         elif isinstance(tp, GenericAlias) and tp.__module__ == "typing":
             origin_name = str(tp).split("[")[0].replace("typing.", "")
-        # Case for Python 3.6's wacky Union
-        elif origin is Union:
-            origin_name = "Union"
         return f"{origin_name}[{', '.join(repr_type(a) for a in args)}]"
     if tp is Ellipsis:
         return "..."

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -8,7 +8,7 @@ from typing import _GenericAlias as GenericAlias  # type: ignore # Python 3.7+
 try:
     from typing import Final  # type: ignore # Python 3.8+
 except ImportError:
-    from typing_extensions import Final  # type: ignore # noqa: F401 # Python 3.6-3.7
+    from typing_extensions import Final  # type: ignore # noqa: F401 # Python 3.7
 
 try:
     from typing import ForwardRef  # type: ignore # Python >= 3.7.4
@@ -23,25 +23,10 @@ except ImportError:
 from erdantic.exceptions import _StringForwardRefError, _UnevaluatedForwardRefError
 
 
-def _get_args(tp):
-    """Backport of typing.get_args for Python 3.6"""
-    return getattr(tp, "__args__", ())
-
-
-def _get_origin(tp):
-    """Backport of typing.get_origin for Python 3.6"""
-    return getattr(tp, "__origin__", None)
-
-
 try:
     from typing import get_args, get_origin  # type: ignore # Python 3.8+
 except ImportError:
-    try:
-        from typing_extensions import get_args, get_origin  # type: ignore # Python 3.7
-    except ImportError:
-        # Python 3.6
-        get_args = _get_args
-        get_origin = _get_origin
+    from typing_extensions import get_args, get_origin  # type: ignore # Python 3.7
 
 
 def get_depth1_bases(tp: type) -> List[type]:

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -1,13 +1,9 @@
 from enum import Enum
 from typing import Any, List, Type, Union
 
-try:
-    from typing import _GenericAlias as GenericAlias  # type: ignore # Python 3.7+
-
-    # Note Python 3.9's types.GenericAlias != typing._GenericAlias
-    # We still want typing._GenericAlias for typing module's deprecated capital generic aliases
-except ImportError:
-    from typing import GenericMeta as GenericAlias  # type: ignore # Python 3.6
+from typing import _GenericAlias as GenericAlias  # type: ignore # Python 3.7+
+# Note Python 3.9's types.GenericAlias != typing._GenericAlias
+# We still want typing._GenericAlias for typing module's deprecated capital generic aliases
 
 try:
     from typing import Final  # type: ignore # Python 3.8+
@@ -22,10 +18,7 @@ except ImportError:
 try:
     from typing import Literal  # type: ignore # Python >= 3.8
 except ImportError:
-    try:
-        from typing_extensions import Literal  # type: ignore # Python ==3.7.*
-    except ImportError:
-        Literal = None  # type: ignore # Python <3.7
+    from typing_extensions import Literal  # type: ignore # Python ==3.7.*
 
 from erdantic.exceptions import _StringForwardRefError, _UnevaluatedForwardRefError
 

--- a/erdantic/typing.py
+++ b/erdantic/typing.py
@@ -10,15 +10,12 @@ try:
 except ImportError:
     from typing_extensions import Final  # type: ignore # noqa: F401 # Python 3.7
 
-try:
-    from typing import ForwardRef  # type: ignore # Python >= 3.7.4
-except ImportError:
-    from typing import _ForwardRef as ForwardRef  # type: ignore # Python < 3.7.4
+from typing import ForwardRef  # docs claim Python >= 3.7.4 but actually it's in Python 3.7.0+
 
 try:
     from typing import Literal  # type: ignore # Python >= 3.8
 except ImportError:
-    from typing_extensions import Literal  # type: ignore # Python ==3.7.*
+    from typing_extensions import Literal  # type: ignore # Python == 3.7.*
 
 from erdantic.exceptions import _StringForwardRefError, _UnevaluatedForwardRefError
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ mike
 mkdocs>=1.2.2
 mkdocs-jupyter
 mkdocs-material>=7.2.6
-mkdocstrings[python]>=0.19.0
+mkdocstrings[python-legacy]>=0.19.0
 mypy
 pytest
 pytest-cases

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,10 +1,7 @@
 import dataclasses
 from typing import Dict, List, Tuple, get_type_hints
 
-try:
-    from typing import ForwardRef  # type: ignore # Python >= 3.7.4
-except ImportError:
-    from typing import _ForwardRef as ForwardRef  # type: ignore # Python < 3.7.4
+from typing import ForwardRef  # docs claim Python >= 3.7.4 but actually it's in Python 3.7.0+
 
 import pytest
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -2,10 +2,7 @@ from enum import Enum, IntFlag
 import sys
 import typing
 
-try:
-    from typing import ForwardRef  # type: ignore # Python >= 3.7.4
-except ImportError:
-    from typing import _ForwardRef as ForwardRef  # type: ignore # Python < 3.7.4
+from typing import ForwardRef  # docs claim Python >= 3.7.4 but actually it's in Python 3.7.0+
 
 try:
     from typing import Literal  # type: ignore # Python >=3.8

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -19,8 +19,6 @@ except ImportError:
 import pytest
 
 from erdantic.typing import (
-    _get_args,
-    _get_origin,
     get_args,
     get_depth1_bases,
     get_origin,
@@ -136,26 +134,3 @@ def test_repr_type_with_mro():
         == "<mro (tests.test_typing.test_repr_type_with_mro.<locals>.FancyInt, int, object)>"
     )
     assert repr_type_with_mro(FancyInt()) == repr(FancyInt())
-
-
-# Test backports against typing module implementations
-if sys.version_info[:2] >= (3, 7):
-
-    backport_cases = [
-        int,
-        typing.List[int],
-        typing.Optional[int],
-        MyClass,
-        typing.List[MyClass],
-        typing.Optional[MyClass],
-    ]
-
-    @pytest.mark.parametrize("tp", backport_cases, ids=[repr_type(c) for c in backport_cases])
-    def test_get_args(tp):
-        assert _get_args is not get_args
-        assert _get_args(tp) == get_args(tp)
-
-    @pytest.mark.parametrize("tp", backport_cases, ids=[repr_type(c) for c in backport_cases])
-    def test_get_origin(tp):
-        assert _get_args is not get_origin
-        assert _get_origin(tp) == get_origin(tp)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -19,9 +19,7 @@ except ImportError:
 import pytest
 
 from erdantic.typing import (
-    get_args,
     get_depth1_bases,
-    get_origin,
     get_recursive_args,
     repr_enum,
     repr_type,


### PR DESCRIPTION
There are a few code paths for handling Python 3.6 typing library quirks. These should no longer be necessary.

Also minor documentation changes:

- Switches mkdocstrings handler back to `python-legacy`. The new `python` handler doesn't yet properly handle properties. https://github.com/mkdocstrings/python/issues/9
- Adds TOC entries for modules so they show up in the Intersphinx inventory file