### PR TITLE
Hold back nbconvert until rendering SVG is fixed

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ mkdocs-jupyter
 mkdocs-material>=7.2.6
 mkdocstrings[python-legacy]>=0.19.0
 mypy
+nbconvert<6.5
 pytest
 pytest-cases
 pytest-cov


### PR DESCRIPTION
This is not an `mkdocs-jupyter` problem (https://github.com/danielfrg/mkdocs-jupyter/issues/92), instead it is a problem with `nbconvert`.

Looks like there was a partial fix here: https://github.com/jupyter/nbconvert/pull/1837
And finishing that is tracked here: https://github.com/jupyter/nbconvert/issues/1849

If repro'd this locally with 6.5, but the docs built successfully at 6.4 Pinning to a lower version for now and will update #68 to track removing this pin when the nbconvert issue is fixed.