### PR TITLE
Update canonical links for previous docs versions

### DIFF
--- a/stable/api-reference/base/index.html
+++ b/stable/api-reference/base/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/base/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/base/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/api-reference/dataclasses/index.html
+++ b/stable/api-reference/dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/api-reference/erd/index.html
+++ b/stable/api-reference/erd/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/erd/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/erd/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/api-reference/examples.dataclasses/index.html
+++ b/stable/api-reference/examples.dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/examples.dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/api-reference/examples.pydantic/index.html
+++ b/stable/api-reference/examples.pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/examples.pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/api-reference/exceptions/index.html
+++ b/stable/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/exceptions/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/api-reference/pydantic/index.html
+++ b/stable/api-reference/pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/changelog/index.html
+++ b/stable/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/changelog/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/cli/index.html
+++ b/stable/cli/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/cli/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/cli/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/examples/dataclasses/index.html
+++ b/stable/examples/dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/examples/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/examples/pydantic/index.html
+++ b/stable/examples/pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/examples/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/extending/index.html
+++ b/stable/extending/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/extending/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/extending/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/forward-references/index.html
+++ b/stable/forward-references/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/forward-references/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/forward-references/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/stable/index.html
+++ b/stable/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.1/api-reference/base/index.html
+++ b/v0.1/api-reference/base/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/api-reference/base/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/base/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/dataclasses/index.html
+++ b/v0.1/api-reference/dataclasses/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/api-reference/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/erd/index.html
+++ b/v0.1/api-reference/erd/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/api-reference/erd/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/erd/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/errors/index.html
+++ b/v0.1/api-reference/errors/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/api-reference/errors/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/errors/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/examples.dataclasses/index.html
+++ b/v0.1/api-reference/examples.dataclasses/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/api-reference/examples.dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/examples.pydantic/index.html
+++ b/v0.1/api-reference/examples.pydantic/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/api-reference/examples.pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/pydantic/index.html
+++ b/v0.1/api-reference/pydantic/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/api-reference/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/changelog/index.html
+++ b/v0.1/changelog/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/changelog/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/cli/index.html
+++ b/v0.1/cli/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/cli/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/cli/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/examples/dataclasses/index.html
+++ b/v0.1/examples/dataclasses/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/examples/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/examples/pydantic/index.html
+++ b/v0.1/examples/pydantic/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/examples/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/extending/index.html
+++ b/v0.1/extending/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/extending/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/extending/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/index.html
+++ b/v0.1/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.1/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/base/index.html
+++ b/v0.2/api-reference/base/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/api-reference/base/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/base/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/dataclasses/index.html
+++ b/v0.2/api-reference/dataclasses/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/api-reference/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/erd/index.html
+++ b/v0.2/api-reference/erd/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/api-reference/erd/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/erd/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/errors/index.html
+++ b/v0.2/api-reference/errors/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/api-reference/errors/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/errors/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/examples.dataclasses/index.html
+++ b/v0.2/api-reference/examples.dataclasses/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/api-reference/examples.dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/examples.pydantic/index.html
+++ b/v0.2/api-reference/examples.pydantic/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/api-reference/examples.pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/pydantic/index.html
+++ b/v0.2/api-reference/pydantic/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/api-reference/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/changelog/index.html
+++ b/v0.2/changelog/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/changelog/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/cli/index.html
+++ b/v0.2/cli/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/cli/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/cli/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/examples/dataclasses/index.html
+++ b/v0.2/examples/dataclasses/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/examples/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/examples/pydantic/index.html
+++ b/v0.2/examples/pydantic/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/examples/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/extending/index.html
+++ b/v0.2/extending/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/extending/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/extending/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/index.html
+++ b/v0.2/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.2/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/base/index.html
+++ b/v0.3/api-reference/base/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/api-reference/base/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/base/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/api-reference/dataclasses/index.html
+++ b/v0.3/api-reference/dataclasses/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/api-reference/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/api-reference/erd/index.html
+++ b/v0.3/api-reference/erd/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/api-reference/erd/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/erd/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/api-reference/examples.dataclasses/index.html
+++ b/v0.3/api-reference/examples.dataclasses/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/api-reference/examples.dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/api-reference/examples.pydantic/index.html
+++ b/v0.3/api-reference/examples.pydantic/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/api-reference/examples.pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/api-reference/exceptions/index.html
+++ b/v0.3/api-reference/exceptions/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/api-reference/exceptions/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/api-reference/pydantic/index.html
+++ b/v0.3/api-reference/pydantic/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/api-reference/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/changelog/index.html
+++ b/v0.3/changelog/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/changelog/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/cli/index.html
+++ b/v0.3/cli/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/cli/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/cli/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/examples/dataclasses/index.html
+++ b/v0.3/examples/dataclasses/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/examples/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/examples/pydantic/index.html
+++ b/v0.3/examples/pydantic/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/examples/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/extending/index.html
+++ b/v0.3/extending/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/extending/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/extending/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/forward-references/index.html
+++ b/v0.3/forward-references/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/forward-references/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/forward-references/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.3/index.html
+++ b/v0.3/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.3/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-7.3.5">

--- a/v0.4/api-reference/base/index.html
+++ b/v0.4/api-reference/base/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/api-reference/base/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/base/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/api-reference/dataclasses/index.html
+++ b/v0.4/api-reference/dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/api-reference/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/api-reference/erd/index.html
+++ b/v0.4/api-reference/erd/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/api-reference/erd/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/erd/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/api-reference/examples.dataclasses/index.html
+++ b/v0.4/api-reference/examples.dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/api-reference/examples.dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/api-reference/examples.pydantic/index.html
+++ b/v0.4/api-reference/examples.pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/api-reference/examples.pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/api-reference/exceptions/index.html
+++ b/v0.4/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/api-reference/exceptions/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/api-reference/pydantic/index.html
+++ b/v0.4/api-reference/pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/api-reference/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/changelog/index.html
+++ b/v0.4/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/changelog/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/cli/index.html
+++ b/v0.4/cli/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/cli/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/cli/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/examples/dataclasses/index.html
+++ b/v0.4/examples/dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/examples/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/examples/pydantic/index.html
+++ b/v0.4/examples/pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/examples/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/extending/index.html
+++ b/v0.4/extending/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/extending/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/extending/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/forward-references/index.html
+++ b/v0.4/forward-references/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/forward-references/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/forward-references/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.4/index.html
+++ b/v0.4/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.4/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.3.0, mkdocs-material-8.2.9">

--- a/v0.5/api-reference/base/index.html
+++ b/v0.5/api-reference/base/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/api-reference/base/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/base/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/api-reference/dataclasses/index.html
+++ b/v0.5/api-reference/dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/api-reference/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/api-reference/erd/index.html
+++ b/v0.5/api-reference/erd/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/api-reference/erd/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/erd/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/api-reference/examples.dataclasses/index.html
+++ b/v0.5/api-reference/examples.dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/api-reference/examples.dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/api-reference/examples.pydantic/index.html
+++ b/v0.5/api-reference/examples.pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/api-reference/examples.pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/api-reference/exceptions/index.html
+++ b/v0.5/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/api-reference/exceptions/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/api-reference/pydantic/index.html
+++ b/v0.5/api-reference/pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/api-reference/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/changelog/index.html
+++ b/v0.5/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/changelog/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/cli/index.html
+++ b/v0.5/cli/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/cli/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/cli/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/examples/dataclasses/index.html
+++ b/v0.5/examples/dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/examples/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/examples/pydantic/index.html
+++ b/v0.5/examples/pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/examples/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/extending/index.html
+++ b/v0.5/extending/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/extending/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/extending/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/forward-references/index.html
+++ b/v0.5/forward-references/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/forward-references/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/forward-references/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.5/index.html
+++ b/v0.5/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.5/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/api-reference/base/index.html
+++ b/v0.6/api-reference/base/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/base/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/base/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/api-reference/dataclasses/index.html
+++ b/v0.6/api-reference/dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/api-reference/erd/index.html
+++ b/v0.6/api-reference/erd/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/erd/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/erd/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/api-reference/examples.dataclasses/index.html
+++ b/v0.6/api-reference/examples.dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/examples.dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/api-reference/examples.pydantic/index.html
+++ b/v0.6/api-reference/examples.pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/examples.pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/examples.pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/api-reference/exceptions/index.html
+++ b/v0.6/api-reference/exceptions/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/exceptions/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/exceptions/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/api-reference/pydantic/index.html
+++ b/v0.6/api-reference/pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/api-reference/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/api-reference/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/changelog/index.html
+++ b/v0.6/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/changelog/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/cli/index.html
+++ b/v0.6/cli/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/cli/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/cli/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/examples/dataclasses/index.html
+++ b/v0.6/examples/dataclasses/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/examples/dataclasses/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/dataclasses/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/examples/pydantic/index.html
+++ b/v0.6/examples/pydantic/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/examples/pydantic/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/examples/pydantic/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/extending/index.html
+++ b/v0.6/extending/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/extending/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/extending/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/forward-references/index.html
+++ b/v0.6/forward-references/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/forward-references/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/forward-references/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">

--- a/v0.6/index.html
+++ b/v0.6/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://erdantic.drivendata.org/v0.6/">
+        <link rel="canonical" href="https://erdantic.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.4.3, mkdocs-material-8.5.10">


### PR DESCRIPTION
This updates the canonical link in previously deployed docs to point to the `stable` version. This will help search engine indexers know to only return results for `stable`.

This updates the files stored on `gh-pages`, which is our staging branch. After merging, we'll need to run any CI job that pushes updated docs for the changes to then be pushed to Netlify.