### PR TITLE
Set mike canonical_version to stable

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,6 +59,8 @@ plugins:
             heading_level: 2
             group_by_category: true
             show_category_heading: true
+  - mike:
+      canonical_version: stable
 
 extra:
   version:


### PR DESCRIPTION
This helps direct search engine indexers to the stable version of the docs. 