### PR TITLE
Pin pytest<8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ mkdocs-material>=7.2.6
 mkdocstrings[python-legacy]>=0.19.0
 mypy
 nbconvert<6.5
-pytest
+pytest<8
 pytest-cases
 pytest-cov
 twine


### PR DESCRIPTION
pytest v8 is incompatible with pytest-cases. See https://github.com/smarie/python-pytest-cases/issues/330