### PR TITLE
Fix CLI help rendering in docs

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -46,7 +46,7 @@ def on_page_read_source(page, **kwargs):
 
 def _inject_cli_help(markdown: str):
     logger.info("Injecting CLI --help output into page markdown")
-    result = runner.invoke(app, ["--help"], prog_name="erdantic")
+    result = runner.invoke(app, ["--help"], prog_name="erdantic", env={"TERM": "dumb"})
     help_text = result.stdout
     return markdown.replace("{{INJECT CLI HELP}}", help_text)
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -108,3 +108,4 @@ extra_css:
 
 watch:
   - ../erdantic
+  - ./hooks.py


### PR DESCRIPTION
Uses `TERM=dumb` environment variable to disable ANSI coloring by rich. 