### PR TITLE
Fix error for typing special forms

### DIFF
--- a/erdantic/core.py
+++ b/erdantic/core.py
@@ -513,7 +513,14 @@ class EntityRelationshipDiagram(pydantic.BaseModel):
 
     def _add_if_model(self, model: type, recurse: bool) -> bool:
         """Private recursive method to add a model to the diagram."""
-        key = str(FullyQualifiedName.from_object(model))
+        try:
+            key = str(FullyQualifiedName.from_object(model))
+        except AttributeError as e:
+            # May get typing special forms that don't have __qualname__ attribute
+            # These are not going to be models
+            if "__qualname__" in str(e):
+                return False
+            raise
         if key not in self.models:
             try:
                 model_info = self._model_info_cls.from_raw_model(model)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,7 @@ import filecmp
 import os
 from pathlib import Path
 import sys
-from typing import List, Optional
+from typing import Any, AnyStr, List, Literal, Optional, TypeVar
 
 if sys.version_info >= (3, 9):
     from typing import Annotated
@@ -12,6 +12,7 @@ else:
     from typing_extensions import Annotated
 
 import IPython.lib.pretty as IPython_pretty
+import pydantic
 import pytest
 import rich
 
@@ -170,6 +171,21 @@ def test_add_unknown_model_type():
     diagram = EntityRelationshipDiagram()
     with pytest.raises(UnknownModelTypeError):
         diagram.add_model(NotAModel)
+
+
+def test_model_with_typing_special_forms():
+    """Models may have special forms in the leaf nodes and we should handle it."""
+
+    T = TypeVar("T")
+
+    class MyModel(pydantic.BaseModel):
+        any_field: Any
+        literal_field: Literal["a", "b", "c"]
+        type_var_field: T
+        anystr_field: AnyStr
+
+    diagram = EntityRelationshipDiagram()
+    diagram.add_model(MyModel)
 
 
 def test_unsupported_forward_ref_resolution(monkeypatch):

--- a/tests/test_typing_utils.py
+++ b/tests/test_typing_utils.py
@@ -48,6 +48,9 @@ def test_get_recursive_args():
         typing.Literal["batman"],
     ]
 
+    T = typing.TypeVar("T")
+    assert get_recursive_args(typing.Union[int, typing.List[T]]) == [int, T]
+
     class SomeForwardRef: ...
 
     with pytest.raises(_UnevaluatedForwardRefError):


### PR DESCRIPTION
Fixes runtime error when adding models that have fields annotated with certain typing special forms like `Any` and `TypeVar` instances.

Closes #114. 