### PR TITLE
Fix error for model with no fields

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # erdantic Changelog
 
+## v1.0.3 (2024-05-10)
+
+- Fixed `StopIteration` error when rendering a model that has no fields. ([Issue #120](https://github.com/drivendataorg/erdantic/issues/120), [PR #121](https://github.com/drivendataorg/erdantic/pull/121))
+
 ## v1.0.2 (2024-04-11)
 
 - Fixed `AttributeError` when adding a model that has a field annotated with certain typing special forms like `Any`, `Literal`, or `TypeVar` instances. ([Issue #114](https://github.com/drivendataorg/erdantic/issues/114), [PR #115](https://github.com/drivendataorg/erdantic/pull/115))

--- a/erdantic/core.py
+++ b/erdantic/core.py
@@ -299,7 +299,11 @@ class ModelInfo(pydantic.BaseModel, Generic[_ModelType]):
             str: DOT language for table
         """
         # Get number of columns dynamically from first row
-        num_cols = next(iter(self.fields.values())).to_dot_row().count("<td")
+        try:
+            num_cols = next(iter(self.fields.values())).to_dot_row().count("<td")
+        except StopIteration:
+            # No fields, so just use 1 column
+            num_cols = 1
         # Concatenate DOT of all rows together
         rows = "\n".join(field_info.to_dot_row() for field_info in self.fields.values()) + "\n"
         return self._dot_table_template.format(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "erdantic"
-version = "1.0.2"
+version = "1.0.3"
 description = "Entity relationship diagrams for Python data model classes like Pydantic."
 readme = "README.md"
 authors = [{ name = "DrivenData", email = "info@drivendata.org" }, { name = "Jay Qi" }]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -188,6 +188,17 @@ def test_model_with_typing_special_forms():
     diagram.add_model(MyModel)
 
 
+def test_model_with_no_fields():
+    """Model with no fields should not error."""
+
+    class EmptyModel(pydantic.BaseModel):
+        pass
+
+    diagram = EntityRelationshipDiagram()
+    diagram.add_model(EmptyModel)
+    diagram.to_dot()
+
+
 def test_unsupported_forward_ref_resolution(monkeypatch):
     """Plugin implementation does not do anything to resolve forward references."""
 


### PR DESCRIPTION
This PR fixes a `StopIteration` error that occurs when trying to render a model with no fields. 

Such models will render with only the header row. This is a simpler fix than excluding the model from rendering. Examples:

![empty_class](https://github.com/drivendataorg/erdantic/assets/2721979/fac92352-bc89-4c67-9a01-95cc8cfb04c3)

![edge_to_empty_class](https://github.com/drivendataorg/erdantic/assets/2721979/061fb72a-18f4-4b05-acc9-62e60a7cbda8)

Closes #120. 