### PR TITLE
Fix improper handling of Annotated when not outermost generic type

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # erdantic Changelog
 
+## v1.0.4 (2024-07-16)
+
+- Fixed handling of `typing.Annotated` in cases where it's not the outermost generic type. ([Issue #122](https://github.com/drivendataorg/erdantic/issues/122), [PR #123](https://github.com/drivendataorg/erdantic/pull/123))
+
 ## v1.0.3 (2024-05-10)
 
 - Fixed `StopIteration` error when rendering a model that has no fields. ([Issue #120](https://github.com/drivendataorg/erdantic/issues/120), [PR #121](https://github.com/drivendataorg/erdantic/pull/121))

--- a/erdantic/core.py
+++ b/erdantic/core.py
@@ -6,15 +6,7 @@ import logging
 import os
 import sys
 import textwrap
-from typing import Any, Dict, Generic, Mapping, Optional, Type, TypeVar, Union
-
-if sys.version_info >= (3, 9):
-    from typing import Annotated, get_args, get_origin
-else:
-    # Annotated added in Python 3.9. typing's get_args and get_origin behave weirdly with
-    # so need to use typing_extensions version
-    from typing_extensions import Annotated, get_args, get_origin
-
+from typing import Any, Dict, Generic, Mapping, Optional, Type, TypeVar, Union, get_args
 
 if sys.version_info >= (3, 11):
     from typing import Self

--- a/erdantic/core.py
+++ b/erdantic/core.py
@@ -142,11 +142,7 @@ class FieldInfo(pydantic.BaseModel):
         Returns:
             Self: _description_
         """
-        if get_origin(raw_type) is Annotated:
-            # Drop the Annotated extra metadata for the string representation
-            type_name = typenames(get_args(raw_type)[0], remove_modules=REMOVE_ALL_MODULES)
-        else:
-            type_name = typenames(raw_type, remove_modules=REMOVE_ALL_MODULES)
+        type_name = typenames(raw_type, remove_modules=REMOVE_ALL_MODULES)
         field_info = cls(
             model_full_name=model_full_name,
             name=name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "erdantic"
-version = "1.0.3"
+version = "1.0.4"
 description = "Entity relationship diagrams for Python data model classes like Pydantic."
 readme = "README.md"
 authors = [{ name = "DrivenData", email = "info@drivendata.org" }, { name = "Jay Qi" }]
@@ -30,7 +30,7 @@ dependencies = [
   "pydantic-core",
   "pygraphviz",
   "sortedcontainers-pydantic",
-  "typenames",
+  "typenames >= 1.3",
   "typer",
   "typing_extensions>4 ; python_version < '3.12'",
 ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -87,6 +87,20 @@ def test_field_info_annotated():
     assert field_info.type_name == "str"
     assert field_info.raw_type == tp
 
+    tp = Annotated[str, object()]
+    field_info = FieldInfo.from_raw_type(
+        model_full_name=FullyQualifiedName.from_object(DummyModel), name="dummy", raw_type=tp
+    )
+    assert field_info.type_name == "str"
+    assert field_info.raw_type == tp
+
+    tp = Optional[Annotated[str, object()]]
+    field_info = FieldInfo.from_raw_type(
+        model_full_name=FullyQualifiedName.from_object(DummyModel), name="dummy", raw_type=tp
+    )
+    assert field_info.type_name == "Optional[str]"
+    assert field_info.raw_type == tp
+
 
 def test_field_not_found_error():
     """A FieldInfo for a model field that does not exist should error if trying to get the raw


### PR DESCRIPTION
Handle `typing.Annotated` with `typenames>=1.3.0`. Closes #122. 