### PR TITLE
Cleanup Python 3.8 code

### DIFF
--- a/erdantic/_repr_utils.py
+++ b/erdantic/_repr_utils.py
@@ -1,12 +1,5 @@
-import sys
+from functools import cache
 from typing import Type
-
-if sys.version_info >= (3, 9):
-    from functools import cache
-else:
-    from functools import lru_cache
-
-    cache = lru_cache(maxsize=None)
 
 from pydantic import BaseModel
 

--- a/erdantic/cli.py
+++ b/erdantic/cli.py
@@ -2,14 +2,8 @@ from enum import Enum
 from importlib import import_module
 import logging
 from pathlib import Path
-import sys
 from types import ModuleType
-from typing import TYPE_CHECKING, List, Optional, Union
-
-if sys.version_info >= (3, 9):
-    from typing import Annotated
-else:
-    from typing_extensions import Annotated
+from typing import TYPE_CHECKING, Annotated, List, Optional, Union
 
 import typer
 

--- a/erdantic/plugins/dataclasses.py
+++ b/erdantic/plugins/dataclasses.py
@@ -3,12 +3,6 @@ import re
 import sys
 from typing import TYPE_CHECKING, Any, List, Type, cast, get_type_hints
 
-if sys.version_info >= (3, 9):
-    # include_extras was added in Python 3.9
-    from typing import get_type_hints
-else:
-    from typing_extensions import get_type_hints
-
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
 else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,12 +4,7 @@ import filecmp
 import os
 from pathlib import Path
 import sys
-from typing import Any, AnyStr, List, Literal, Optional, Tuple, TypeVar
-
-if sys.version_info >= (3, 9):
-    from typing import Annotated
-else:
-    from typing_extensions import Annotated
+from typing import Annotated, Any, AnyStr, List, Literal, Optional, Tuple, TypeVar
 
 import IPython.lib.pretty as IPython_pretty
 import pydantic

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -1,13 +1,7 @@
 import dataclasses
 from dataclasses import dataclass
 from pprint import pprint
-import sys
-from typing import Optional
-
-if sys.version_info >= (3, 9):
-    from typing import Annotated, get_type_hints
-else:
-    from typing_extensions import Annotated, get_type_hints
+from typing import Annotated, Optional, get_type_hints
 
 import pytest
 


### PR DESCRIPTION
Removes code related to Python 3.8 support. 