### PR TITLE
Standard collections type annotations

### DIFF
--- a/erdantic/cli.py
+++ b/erdantic/cli.py
@@ -3,7 +3,7 @@ from importlib import import_module
 import logging
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Annotated, List, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Optional, Union
 
 import typer
 
@@ -74,7 +74,7 @@ def list_plugins_callback(list_plugins: bool):
 @app.command()
 def main(
     models_or_modules: Annotated[
-        List[str],
+        list[str],
         typer.Argument(
             help=(
                 "One or more full dotted paths for data model classes, or modules containing data "
@@ -89,7 +89,7 @@ def main(
         typer.Option("--out", "-o", help="Output filename."),
     ],
     terminal_models: Annotated[
-        List[str],
+        list[str],
         typer.Option(
             "--terminal-model",
             "-t",
@@ -101,14 +101,14 @@ def main(
         ),
     ] = [],
     termini: Annotated[
-        List[str],
+        list[str],
         typer.Option(
             "--terminus",
             help=("Deprecated. Use --terminal-model instead."),
         ),
     ] = [],
     limit_search_models_to: Annotated[
-        List[AvailablePluginKeys],
+        list[AvailablePluginKeys],
         typer.Option(
             "--limit-search-models-to",
             "-m",

--- a/erdantic/convenience.py
+++ b/erdantic/convenience.py
@@ -1,8 +1,9 @@
+from collections.abc import Mapping
 import inspect
 import logging
 import os
 from types import ModuleType
-from typing import Any, Collection, Iterator, Mapping, Optional, Union
+from typing import Any, Collection, Iterator, Optional, Union
 import warnings
 
 from typenames import REMOVE_ALL_MODULES, typenames

--- a/erdantic/core.py
+++ b/erdantic/core.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from enum import Enum
 from functools import total_ordering
 from importlib import import_module
@@ -6,7 +7,7 @@ import logging
 import os
 import sys
 import textwrap
-from typing import Any, Dict, Generic, Mapping, Optional, Type, TypeVar, Union, get_args
+from typing import Any, Dict, Generic, Optional, Type, TypeVar, Union, get_args
 
 if sys.version_info >= (3, 11):
     from typing import Self

--- a/erdantic/exceptions.py
+++ b/erdantic/exceptions.py
@@ -1,5 +1,5 @@
 import sys
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from erdantic.core import FullyQualifiedName
@@ -118,10 +118,10 @@ class UnknownModelTypeError(ValueError, ErdanticException):
 
     Attributes:
         model (type): The model class that was not recognized.
-        available_plugins (List[str]): List of plugin keys that were available.
+        available_plugins (list[str]): List of plugin keys that were available.
     """
 
-    def __init__(self, *args, model: type, available_plugins: List[str]):
+    def __init__(self, *args, model: type, available_plugins: list[str]):
         mro = getattr(model, "__mro__", str(model))
         message = (
             "Given model does not match any supported types. "

--- a/erdantic/plugins/__init__.py
+++ b/erdantic/plugins/__init__.py
@@ -1,7 +1,7 @@
 import importlib.metadata
 import logging
 import sys
-from typing import TYPE_CHECKING, Any, List, Optional, Protocol, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, Protocol, Sequence, TypeVar
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -75,7 +75,7 @@ def register_plugin(
     _dict[key] = (predicate_fn, get_fields_fn)
 
 
-def list_plugins() -> List[str]:
+def list_plugins() -> list[str]:
     """List the keys of all registered plugins."""
     return list(_dict.keys())
 

--- a/erdantic/plugins/attrs.py
+++ b/erdantic/plugins/attrs.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from typing import Any, List, Type
+from typing import Any, Type
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -28,14 +28,14 @@ def is_attrs_class(obj: Any) -> TypeGuard[AttrsClassType]:
     return isinstance(obj, type) and attrs.has(obj)
 
 
-def get_fields_from_attrs_class(model: AttrsClassType) -> List[FieldInfo]:
+def get_fields_from_attrs_class(model: AttrsClassType) -> list[FieldInfo]:
     """Given an attrs class, return a list of FieldInfo instances for each field in the class.
 
     Args:
         model (AttrsClassType): The attrs class to get fields from.
 
     Returns:
-        List[FieldInfo]: List of FieldInfo instances for each field in the class
+        list[FieldInfo]: List of FieldInfo instances for each field in the class
     """
     try:
         # Try to automatically resolve forward references

--- a/erdantic/plugins/dataclasses.py
+++ b/erdantic/plugins/dataclasses.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 import sys
-from typing import TYPE_CHECKING, Any, List, Type, cast, get_type_hints
+from typing import TYPE_CHECKING, Any, Type, cast, get_type_hints
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -31,14 +31,14 @@ def is_dataclass_class(obj: Any) -> TypeGuard[DataclassType]:
     return isinstance(obj, type) and dataclasses.is_dataclass(obj)
 
 
-def get_fields_from_dataclass(model: DataclassType) -> List[FieldInfo]:
+def get_fields_from_dataclass(model: DataclassType) -> list[FieldInfo]:
     """Given a dataclass, return a list of FieldInfo instances for each field in the class.
 
     Args:
         model (DataclassType): The dataclass to get fields from.
 
     Returns:
-        List[FieldInfo]: List of FieldInfo instances for each field in the class
+        list[FieldInfo]: List of FieldInfo instances for each field in the class
     """
     try:
         # Try to automatically resolve forward references

--- a/erdantic/plugins/msgspec.py
+++ b/erdantic/plugins/msgspec.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from typing import Any, List, Type
+from typing import Any, Type
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -28,7 +28,7 @@ def is_msgspec_struct(obj: Any) -> TypeGuard[MsgspecStruct]:
     return isinstance(obj, type) and issubclass(obj, msgspec.Struct)
 
 
-def get_fields_from_msgspec_struct(model: MsgspecStruct) -> List[FieldInfo]:
+def get_fields_from_msgspec_struct(model: MsgspecStruct) -> list[FieldInfo]:
     """Given a msgspec struct, return a list of FieldInfo instances for each field in the
     struct.
 
@@ -36,7 +36,7 @@ def get_fields_from_msgspec_struct(model: MsgspecStruct) -> List[FieldInfo]:
         model (PydanticModel): The struct to get fields from.
 
     Returns:
-        List[FieldInfo]: List of FieldInfo instances for each field in the struct
+        list[FieldInfo]: List of FieldInfo instances for each field in the struct
     """
     try:
         msgspec._utils.get_class_annotations(model)  # type: ignore [attr-defined]

--- a/erdantic/plugins/pydantic.py
+++ b/erdantic/plugins/pydantic.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from typing import Any, List, Optional, Type
+from typing import Any, Optional, Type
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -31,14 +31,14 @@ def is_pydantic_model(obj: Any) -> TypeGuard[PydanticModel]:
     return isinstance(obj, type) and issubclass(obj, pydantic.BaseModel)
 
 
-def get_fields_from_pydantic_model(model: PydanticModel) -> List[FieldInfo]:
+def get_fields_from_pydantic_model(model: PydanticModel) -> list[FieldInfo]:
     """Given a Pydantic model, return a list of FieldInfo instances for each field in the model.
 
     Args:
         model (PydanticModel): The Pydantic model to get fields from.
 
     Returns:
-        List[FieldInfo]: List of FieldInfo instances for each field in the model
+        list[FieldInfo]: List of FieldInfo instances for each field in the model
     """
     try:
         # Rebuild model schema to resolve forward references
@@ -88,14 +88,14 @@ def is_pydantic_v1_model(obj) -> TypeGuard[PydanticV1Model]:
     return isinstance(obj, type) and issubclass(obj, pydantic.v1.BaseModel)
 
 
-def get_fields_from_pydantic_v1_model(model: PydanticV1Model) -> List[FieldInfo]:
+def get_fields_from_pydantic_v1_model(model: PydanticV1Model) -> list[FieldInfo]:
     """Given a Pydantic V1 model, return a list of FieldInfo instances for each field in the model.
 
     Args:
         model (PydanticV1Model): The Pydantic V1 model to get fields from.
 
     Returns:
-        List[FieldInfo]: List of FieldInfo instances for each field in the model
+        list[FieldInfo]: List of FieldInfo instances for each field in the model
     """
     try:
         model.update_forward_refs()

--- a/erdantic/typing_utils.py
+++ b/erdantic/typing_utils.py
@@ -1,6 +1,6 @@
 import collections.abc
 import sys
-from typing import Any, ForwardRef, Iterator, List, Literal, TypeVar, Union, get_args, get_origin
+from typing import Any, ForwardRef, Iterator, Literal, TypeVar, Union, get_args, get_origin
 
 from typenames import BaseNode, GenericNode, parse_type_tree
 
@@ -60,13 +60,13 @@ def is_nullable_type(tp: _TypeForm) -> bool:
     return get_origin(tp) is Union and type(None) in get_args(tp)
 
 
-def get_depth1_bases(tp: type) -> List[type]:
+def get_depth1_bases(tp: type) -> list[type]:
     """Returns depth-1 base classes of a type."""
     bases_of_bases = {bb for b in tp.__mro__[1:] for bb in b.__mro__[1:]}
     return [b for b in tp.__mro__[1:] if b not in bases_of_bases]
 
 
-def get_recursive_args(tp: _TypeForm) -> List[_TypeForm]:
+def get_recursive_args(tp: _TypeForm) -> list[_TypeForm]:
     """Recursively finds leaf-node types of possibly-nested generic type."""
 
     def recurse(t: _TypeForm) -> Iterator[_TypeForm]:

--- a/tests/pydantic_with_default_column.py
+++ b/tests/pydantic_with_default_column.py
@@ -1,5 +1,5 @@
 from html import escape
-from typing import Any, Dict, List
+from typing import Any
 
 import pydantic
 import pydantic_core
@@ -57,7 +57,7 @@ class FieldInfoWithDefault(FieldInfo):
 class ModelInfoWithDefault(ModelInfo):
     """Custom ModelInfo subclass that uses FieldInfoWithDefault instead of FieldInfo."""
 
-    fields: Dict[str, FieldInfoWithDefault] = {}
+    fields: dict[str, FieldInfoWithDefault] = {}
 
 
 class EntityRelationshipDiagramWithDefault(EntityRelationshipDiagram):
@@ -68,7 +68,7 @@ class EntityRelationshipDiagramWithDefault(EntityRelationshipDiagram):
     models: SortedDict[str, ModelInfoWithDefault] = SortedDict()
 
 
-def get_fields_from_pydantic_model_with_default(model) -> List[FieldInfoWithDefault]:
+def get_fields_from_pydantic_model_with_default(model) -> list[FieldInfoWithDefault]:
     """Copied from erdantic.plugins.pydantic.get_fields_from_pydantic_model and modified to
     extract default values of fields.
     """


### PR DESCRIPTION
Migrate collection generic type annotations to use builtins instead of `typing` aliases. 