### PR TITLE
feat(export): Add D2 class diagram output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # erdantic Changelog
 
+## v1.2.0 (2025-09-13)
+
+- Added support for the D2 diagramming language for class diagrams. Use `EntityRelationshipDiagram.to_d2()` to get the D2 representation programmatically, or the CLI flag `--d2` to print it to stdout. The `--dot` and `--d2` options are mutually exclusive, and `-o`/`--out` is ignored when `--d2` is used. ([PR #152](https://github.com/drivendataorg/erdantic/pull/152), thanks to [@Else00](https://github.com/Else00))
+
 ## v1.1.1 (2025-07-19)
 
 - Changed `plugins.pydantic.get_fields_from_pydantic_model` to force model rebuild. This helps address cases of unresolved forward references where Pydantic mistakenly skips rebuilding. Fixes [#153](https://github.com/drivendataorg/erdantic/issues/153). ([PR #154](https://github.com/drivendataorg/erdantic/pull/154))

--- a/erdantic/core.py
+++ b/erdantic/core.py
@@ -678,6 +678,19 @@ class EntityRelationshipDiagram(pydantic.BaseModel):
             edge_attr=edge_attr,
         ).string()
 
+    def to_d2(self) -> str:
+        """Generate D2 class diagram representation of the entity relationship diagram.
+
+        Returns:
+            str: D2 language representation of diagram
+        """
+
+        # Lazy import to avoid a circular import: the D2 renderer refers back to core types.
+        # This can be refactored later as discussed in the PR review.
+        from erdantic.d2 import render_d2
+
+        return render_d2(self)
+
     def _repr_pretty_(self, p, cycle):
         """IPython special method to pretty-print an object."""
         try:

--- a/erdantic/d2.py
+++ b/erdantic/d2.py
@@ -63,10 +63,7 @@ def render_d2(diagram: EntityRelationshipDiagram) -> str:
             for field in model.fields.values():
                 field_type = _maybe_quote_value(field.type_name)
                 visibility = _get_visibility_prefix(field.name)
-                # Strip leading underscores from the name for a cleaner look in the diagram
-                field_name_clean = field.name.lstrip("_")
-                field_name = field_name_clean
-                class_def.append(f"  {visibility}{field_name}: {field_type}")
+                class_def.append(f"  {visibility}{field.name}: {field_type}")
 
         class_def.append("}\n")
         d2_parts.append("\n".join(class_def))

--- a/erdantic/d2.py
+++ b/erdantic/d2.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from erdantic.core import Cardinality, Edge, EntityRelationshipDiagram, Modality
+
+
+def _escape_quotes(s: str) -> str:
+    return s.replace('"', r"\"")
+
+
+def _quote_identifier(name: str) -> str:
+    """Always quote D2 identifiers used as shape keys and connection labels.
+    Note: field names inside class bodies are intentionally not quoted to match snapshots."""
+    return f'"{_escape_quotes(name)}"'
+
+
+def _maybe_quote_value(value: str) -> str:
+    """Quote values only if they contain special characters (e.g., type annotations)."""
+    if any(c in value for c in " -.,;()[]{}<>|"):
+        return f'"{_escape_quotes(value)}"'
+    return value
+
+
+def _get_visibility_prefix(name: str) -> str:
+    """Determines the UML visibility prefix based on Python's naming conventions."""
+    if name.startswith("__") and not name.endswith("__"):
+        return "-"  # Private
+    elif name.startswith("_") and not name.endswith("_"):
+        return "#"  # Protected
+    else:
+        return "+"  # Public
+
+
+def _get_d2_cardinality(edge: Edge) -> str:
+    """Map (Cardinality, Modality) to D2 crow's-foot arrowheads (no quotes)."""
+    c = edge.target_cardinality
+    m = edge.target_modality
+
+    # MANY
+    if c == Cardinality.MANY:
+        # Only four arrowheads exist for crow's foot; map unspecified to non-required
+        return "cf-many-required" if m == Modality.ONE else "cf-many"
+
+    # ONE
+    if c == Cardinality.ONE:
+        return "cf-one-required" if m == Modality.ONE else "cf-one"
+
+    # UNSPECIFIED cardinality -> treat as ONE by default
+    return "cf-one-required" if m == Modality.ONE else "cf-one"
+
+
+def render_d2(diagram: EntityRelationshipDiagram) -> str:
+    """Renders an EntityRelationshipDiagram into the D2 class diagram format."""
+    d2_parts: list[str] = []
+
+    # Define all class shapes first
+    for model in diagram.models.values():
+        class_name = _quote_identifier(model.name)
+        class_def = [f"{class_name}: {{", "  shape: class"]
+
+        if not model.fields:
+            class_def.append("  # This class has no fields to display in the diagram.")
+        else:
+            for field in model.fields.values():
+                field_type = _maybe_quote_value(field.type_name)
+                visibility = _get_visibility_prefix(field.name)
+                # Strip leading underscores from the name for a cleaner look in the diagram
+                field_name_clean = field.name.lstrip("_")
+                field_name = field_name_clean
+                class_def.append(f"  {visibility}{field_name}: {field_type}")
+
+        class_def.append("}\n")
+        d2_parts.append("\n".join(class_def))
+
+    # Define all relationships between classes
+    for edge in diagram.edges.values():
+        source_model = diagram.models.get(str(edge.source_model_full_name))
+        target_model = diagram.models.get(str(edge.target_model_full_name))
+        if not source_model or not target_model:
+            continue
+
+        source_model_name = _quote_identifier(source_model.name)
+        target_model_name = _quote_identifier(target_model.name)
+        label = _quote_identifier(edge.source_field_name)
+
+        rel_def_line = f"{source_model_name} -> {target_model_name}: {label}"
+        d2_cardinality = _get_d2_cardinality(edge)
+
+        # Use D2 crow's-foot token without quotes
+        rel_def = [f"{rel_def_line} {{", f"  target-arrowhead: {d2_cardinality}", "}\n"]
+        d2_parts.append("\n".join(rel_def))
+
+    return "\n".join(d2_parts)

--- a/erdantic/d2.py
+++ b/erdantic/d2.py
@@ -86,7 +86,7 @@ def render_d2(diagram: EntityRelationshipDiagram) -> str:
         d2_cardinality = _get_d2_cardinality(edge)
 
         # Use D2 crow's-foot token without quotes
-        rel_def = [f"{rel_def_line} {{", f"  target-arrowhead: {d2_cardinality}", "}\n"]
+        rel_def = [f"{rel_def_line} {{", f"  target-arrowhead.shape: {d2_cardinality}", "}\n"]
         d2_parts.append("\n".join(rel_def))
 
     return "\n".join(d2_parts)

--- a/tests/assets/attrs.d2
+++ b/tests/assets/attrs.d2
@@ -29,13 +29,13 @@
 }
 
 "Party" -> "Quest": "active_quest" {
-  target-arrowhead: cf-one
+  target-arrowhead.shape: cf-one
 }
 
 "Party" -> "Adventurer": "members" {
-  target-arrowhead: cf-many
+  target-arrowhead.shape: cf-many
 }
 
 "Quest" -> "QuestGiver": "giver" {
-  target-arrowhead: cf-one-required
+  target-arrowhead.shape: cf-one-required
 }

--- a/tests/assets/attrs.d2
+++ b/tests/assets/attrs.d2
@@ -1,0 +1,41 @@
+"Adventurer": {
+  shape: class
+  +name: str
+  +profession: str
+  +alignment: Alignment
+  +level: int
+}
+
+"Party": {
+  shape: class
+  +name: str
+  +formed_datetime: datetime
+  +members: "list[Adventurer]"
+  +active_quest: "Optional[Quest]"
+}
+
+"Quest": {
+  shape: class
+  +name: str
+  +giver: QuestGiver
+  +reward_gold: int
+}
+
+"QuestGiver": {
+  shape: class
+  +name: str
+  +faction: "Optional[str]"
+  +location: str
+}
+
+"Party" -> "Quest": "active_quest" {
+  target-arrowhead: cf-one
+}
+
+"Party" -> "Adventurer": "members" {
+  target-arrowhead: cf-many
+}
+
+"Quest" -> "QuestGiver": "giver" {
+  target-arrowhead: cf-one-required
+}

--- a/tests/assets/dataclasses.d2
+++ b/tests/assets/dataclasses.d2
@@ -29,13 +29,13 @@
 }
 
 "Party" -> "Quest": "active_quest" {
-  target-arrowhead: cf-one
+  target-arrowhead.shape: cf-one
 }
 
 "Party" -> "Adventurer": "members" {
-  target-arrowhead: cf-many
+  target-arrowhead.shape: cf-many
 }
 
 "Quest" -> "QuestGiver": "giver" {
-  target-arrowhead: cf-one-required
+  target-arrowhead.shape: cf-one-required
 }

--- a/tests/assets/dataclasses.d2
+++ b/tests/assets/dataclasses.d2
@@ -1,0 +1,41 @@
+"Adventurer": {
+  shape: class
+  +name: str
+  +profession: str
+  +alignment: Alignment
+  +level: int
+}
+
+"Party": {
+  shape: class
+  +name: str
+  +formed_datetime: datetime
+  +members: "list[Adventurer]"
+  +active_quest: "Optional[Quest]"
+}
+
+"Quest": {
+  shape: class
+  +name: str
+  +giver: QuestGiver
+  +reward_gold: int
+}
+
+"QuestGiver": {
+  shape: class
+  +name: str
+  +faction: "Optional[str]"
+  +location: str
+}
+
+"Party" -> "Quest": "active_quest" {
+  target-arrowhead: cf-one
+}
+
+"Party" -> "Adventurer": "members" {
+  target-arrowhead: cf-many
+}
+
+"Quest" -> "QuestGiver": "giver" {
+  target-arrowhead: cf-one-required
+}

--- a/tests/assets/pydantic.d2
+++ b/tests/assets/pydantic.d2
@@ -29,13 +29,13 @@
 }
 
 "Party" -> "Quest": "active_quest" {
-  target-arrowhead: cf-one
+  target-arrowhead.shape: cf-one
 }
 
 "Party" -> "Adventurer": "members" {
-  target-arrowhead: cf-many
+  target-arrowhead.shape: cf-many
 }
 
 "Quest" -> "QuestGiver": "giver" {
-  target-arrowhead: cf-one-required
+  target-arrowhead.shape: cf-one-required
 }

--- a/tests/assets/pydantic.d2
+++ b/tests/assets/pydantic.d2
@@ -1,0 +1,41 @@
+"Adventurer": {
+  shape: class
+  +name: str
+  +profession: str
+  +alignment: Alignment
+  +level: int
+}
+
+"Party": {
+  shape: class
+  +name: str
+  +formed_datetime: datetime
+  +members: "list[Adventurer]"
+  +active_quest: "Optional[Quest]"
+}
+
+"Quest": {
+  shape: class
+  +name: str
+  +giver: QuestGiver
+  +reward_gold: int
+}
+
+"QuestGiver": {
+  shape: class
+  +name: str
+  +faction: "Optional[str]"
+  +location: str
+}
+
+"Party" -> "Quest": "active_quest" {
+  target-arrowhead: cf-one
+}
+
+"Party" -> "Adventurer": "members" {
+  target-arrowhead: cf-many
+}
+
+"Quest" -> "QuestGiver": "giver" {
+  target-arrowhead: cf-one-required
+}

--- a/tests/assets/pydantic_v1.d2
+++ b/tests/assets/pydantic_v1.d2
@@ -29,13 +29,13 @@
 }
 
 "Party" -> "Quest": "active_quest" {
-  target-arrowhead: cf-one
+  target-arrowhead.shape: cf-one
 }
 
 "Party" -> "Adventurer": "members" {
-  target-arrowhead: cf-many
+  target-arrowhead.shape: cf-many
 }
 
 "Quest" -> "QuestGiver": "giver" {
-  target-arrowhead: cf-one-required
+  target-arrowhead.shape: cf-one-required
 }

--- a/tests/assets/pydantic_v1.d2
+++ b/tests/assets/pydantic_v1.d2
@@ -1,0 +1,41 @@
+"Adventurer": {
+  shape: class
+  +name: str
+  +profession: str
+  +alignment: Alignment
+  +level: int
+}
+
+"Party": {
+  shape: class
+  +name: str
+  +formed_datetime: datetime
+  +members: "list[Adventurer]"
+  +active_quest: "Optional[Quest]"
+}
+
+"Quest": {
+  shape: class
+  +name: str
+  +giver: QuestGiver
+  +reward_gold: int
+}
+
+"QuestGiver": {
+  shape: class
+  +name: str
+  +faction: "Optional[str]"
+  +location: str
+}
+
+"Party" -> "Quest": "active_quest" {
+  target-arrowhead: cf-one
+}
+
+"Party" -> "Adventurer": "members" {
+  target-arrowhead: cf-many
+}
+
+"Quest" -> "QuestGiver": "giver" {
+  target-arrowhead: cf-one-required
+}

--- a/tests/test_against_assets.py
+++ b/tests/test_against_assets.py
@@ -81,3 +81,21 @@ def test_json_against_static_assets(case, outputs_dir, version_patch):
 
     expected_diagram = erd.EntityRelationshipDiagram.model_validate_json(expected_path.read_text())
     assert diagram == expected_diagram
+
+
+@pytest.mark.parametrize("case", CASES)
+def test_to_d2_against_static_assets(case, outputs_dir, version_patch):
+    """Uses to_d2 method to test against static assets."""
+    plugin, model_or_module = case
+    expected_path = ASSETS_DIR / f"{plugin}.d2"
+
+    # to_d2 is not a convenience function, so we always create the diagram first
+    diagram = erd.create(model_or_module)
+    out = diagram.to_d2()
+
+    # Write our own asset for inspection
+    out_path = outputs_dir / f"{plugin}.d2"
+    out_path.write_text(out)
+
+    # Compare to expected
+    assert out.strip() == expected_path.read_text().strip()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,3 +246,22 @@ def test_version():
     print(result.output)
     assert result.exit_code == 0
     assert result.output.strip() == __version__
+
+
+def test_d2(tmp_path):
+    """Test the --d2 flag."""
+    # Test that it produces the expected output
+    result = runner.invoke(app, ["erdantic.examples.pydantic.Party", "--d2"])
+    assert result.exit_code == 0
+    expected_out = erd.create(erd.examples.pydantic.Party).to_d2()
+    assert result.stdout.strip() == expected_out.strip()
+
+    # Test that -o is ignored and no file is created
+    path = tmp_path / "diagram.d2"
+    result = runner.invoke(app, ["erdantic.examples.pydantic.Party", "--d2", "-o", str(path)])
+    assert result.exit_code == 0
+    assert not path.exists()
+
+    # Test that --dot and --d2 are mutually exclusive
+    result = runner.invoke(app, ["erdantic.examples.pydantic.Party", "--dot", "--d2"])
+    assert result.exit_code == 1

--- a/tests/test_d2.py
+++ b/tests/test_d2.py
@@ -27,11 +27,11 @@ def test_render_d2():
 
     # Check for relationships and crow's foot
     assert '"Party" -> "Adventurer": "members"' in d2_string
-    assert "target-arrowhead: cf-many" in d2_string
+    assert "target-arrowhead.shape: cf-many" in d2_string
     assert '"Party" -> "Quest": "active_quest"' in d2_string
-    assert "target-arrowhead: cf-one" in d2_string
+    assert "target-arrowhead.shape: cf-one" in d2_string
     assert '"Quest" -> "QuestGiver": "giver"' in d2_string
-    assert "target-arrowhead: cf-one-required" in d2_string
+    assert "target-arrowhead.shape: cf-one-required" in d2_string
 
 
 def test_get_visibility_prefix():

--- a/tests/test_d2.py
+++ b/tests/test_d2.py
@@ -1,0 +1,88 @@
+import erdantic as erd
+from erdantic.examples import pydantic
+from erdantic.d2 import (
+    _get_d2_cardinality,
+    _quote_identifier,
+    _maybe_quote_value,
+    _get_visibility_prefix,
+    render_d2,
+)
+from erdantic.core import Cardinality, Modality
+
+
+def test_render_d2():
+    """Test full D2 rendering."""
+    diagram = erd.create(pydantic.Party)
+    d2_string = render_d2(diagram)
+
+    # Check for class definitions (identifiers are always quoted)
+    assert "\"Party\": {\n  shape: class" in d2_string
+    assert "\"Adventurer\": {\n  shape: class" in d2_string
+    assert "\"Quest\": {\n  shape: class" in d2_string
+    assert "\"QuestGiver\": {\n  shape: class" in d2_string
+
+    # Check for fields
+    assert "+name: str" in d2_string
+    assert "+active_quest: \"Optional[Quest]\"" in d2_string
+
+    # Check for relationships and crow's foot
+    assert "\"Party\" -> \"Adventurer\": \"members\"" in d2_string
+    assert "target-arrowhead: cf-many" in d2_string
+    assert "\"Party\" -> \"Quest\": \"active_quest\"" in d2_string
+    assert "target-arrowhead: cf-one" in d2_string
+    assert "\"Quest\" -> \"QuestGiver\": \"giver\"" in d2_string
+    assert "target-arrowhead: cf-one-required" in d2_string
+
+
+def test_get_visibility_prefix():
+    """Test visibility prefix determination."""
+    assert _get_visibility_prefix("public_field") == "+"
+    assert _get_visibility_prefix("_protected_field") == "#"
+    assert _get_visibility_prefix("__private_field") == "-"
+
+
+def test_identifier_and_value_quoting():
+    """Identifiers are always quoted; values only when special."""
+    assert _quote_identifier("ValidName") == "\"ValidName\""
+    assert _quote_identifier("name with space") == "\"name with space\""
+    assert _maybe_quote_value("str") == "str"
+    assert _maybe_quote_value("list[Item]") == "\"list[Item]\""
+    assert _maybe_quote_value("Foo | None") == "\"Foo | None\""
+
+
+def test_quote_identifier_escapes_double_quotes():
+    """Ensure embedded quotes are escaped inside quoted identifiers."""
+    assert _quote_identifier('He said "hi"') == '"He said \\"hi\\""'
+
+def test_get_d2_cardinality_unspecified_combinations():
+    """Explicitly cover UNSPECIFIED cardinality/modality combos."""
+    # Prendiamo un edge qualsiasi e modifichiamo i campi
+    diagram = erd.create(pydantic.Party)
+    edge = next(iter(diagram.edges.values()))
+    e = edge.model_copy()
+
+    # UNSPECIFIED cardinality behaves like ONE; required only if Modality.ONE
+    e.target_cardinality = Cardinality.UNSPECIFIED
+    e.target_modality = Modality.UNSPECIFIED
+    assert _get_d2_cardinality(e) == "cf-one"
+
+    e.target_cardinality = Cardinality.UNSPECIFIED
+    e.target_modality = Modality.ZERO
+    assert _get_d2_cardinality(e) == "cf-one"
+
+    e.target_cardinality = Cardinality.UNSPECIFIED
+    e.target_modality = Modality.ONE
+    assert _get_d2_cardinality(e) == "cf-one-required"
+
+    # Sanity checks for explicit ONE/MANY remain consistent
+    e.target_cardinality = Cardinality.ONE
+    e.target_modality = Modality.ZERO
+    assert _get_d2_cardinality(e) == "cf-one"
+
+    e.target_cardinality = Cardinality.MANY
+    e.target_modality = Modality.UNSPECIFIED
+    assert _get_d2_cardinality(e) == "cf-many"
+
+    e.target_cardinality = Cardinality.MANY
+    e.target_modality = Modality.ONE
+    assert _get_d2_cardinality(e) == "cf-many-required"

--- a/tests/test_d2.py
+++ b/tests/test_d2.py
@@ -56,7 +56,7 @@ def test_quote_identifier_escapes_double_quotes():
 
 def test_get_d2_cardinality_unspecified_combinations():
     """Explicitly cover UNSPECIFIED cardinality/modality combos."""
-    # Prendiamo un edge qualsiasi e modifichiamo i campi
+    # Take any edge and modify the fields
     diagram = erd.create(pydantic.Party)
     edge = next(iter(diagram.edges.values()))
     e = edge.model_copy()

--- a/tests/test_d2.py
+++ b/tests/test_d2.py
@@ -1,13 +1,13 @@
 import erdantic as erd
-from erdantic.examples import pydantic
+from erdantic.core import Cardinality, Modality
 from erdantic.d2 import (
     _get_d2_cardinality,
-    _quote_identifier,
-    _maybe_quote_value,
     _get_visibility_prefix,
+    _maybe_quote_value,
+    _quote_identifier,
     render_d2,
 )
-from erdantic.core import Cardinality, Modality
+from erdantic.examples import pydantic
 
 
 def test_render_d2():
@@ -16,21 +16,21 @@ def test_render_d2():
     d2_string = render_d2(diagram)
 
     # Check for class definitions (identifiers are always quoted)
-    assert "\"Party\": {\n  shape: class" in d2_string
-    assert "\"Adventurer\": {\n  shape: class" in d2_string
-    assert "\"Quest\": {\n  shape: class" in d2_string
-    assert "\"QuestGiver\": {\n  shape: class" in d2_string
+    assert '"Party": {\n  shape: class' in d2_string
+    assert '"Adventurer": {\n  shape: class' in d2_string
+    assert '"Quest": {\n  shape: class' in d2_string
+    assert '"QuestGiver": {\n  shape: class' in d2_string
 
     # Check for fields
     assert "+name: str" in d2_string
-    assert "+active_quest: \"Optional[Quest]\"" in d2_string
+    assert '+active_quest: "Optional[Quest]"' in d2_string
 
     # Check for relationships and crow's foot
-    assert "\"Party\" -> \"Adventurer\": \"members\"" in d2_string
+    assert '"Party" -> "Adventurer": "members"' in d2_string
     assert "target-arrowhead: cf-many" in d2_string
-    assert "\"Party\" -> \"Quest\": \"active_quest\"" in d2_string
+    assert '"Party" -> "Quest": "active_quest"' in d2_string
     assert "target-arrowhead: cf-one" in d2_string
-    assert "\"Quest\" -> \"QuestGiver\": \"giver\"" in d2_string
+    assert '"Quest" -> "QuestGiver": "giver"' in d2_string
     assert "target-arrowhead: cf-one-required" in d2_string
 
 
@@ -43,16 +43,17 @@ def test_get_visibility_prefix():
 
 def test_identifier_and_value_quoting():
     """Identifiers are always quoted; values only when special."""
-    assert _quote_identifier("ValidName") == "\"ValidName\""
-    assert _quote_identifier("name with space") == "\"name with space\""
+    assert _quote_identifier("ValidName") == '"ValidName"'
+    assert _quote_identifier("name with space") == '"name with space"'
     assert _maybe_quote_value("str") == "str"
-    assert _maybe_quote_value("list[Item]") == "\"list[Item]\""
-    assert _maybe_quote_value("Foo | None") == "\"Foo | None\""
+    assert _maybe_quote_value("list[Item]") == '"list[Item]"'
+    assert _maybe_quote_value("Foo | None") == '"Foo | None"'
 
 
 def test_quote_identifier_escapes_double_quotes():
     """Ensure embedded quotes are escaped inside quoted identifiers."""
     assert _quote_identifier('He said "hi"') == '"He said \\"hi\\""'
+
 
 def test_get_d2_cardinality_unspecified_combinations():
     """Explicitly cover UNSPECIFIED cardinality/modality combos."""


### PR DESCRIPTION
### Summary

This PR introduces a new output format to `erdantic`, allowing users to generate class diagrams using the [D2 declarative diagramming language](https://d2lang.com/).

### Motivation

While `erdantic`'s default Graphviz output is excellent, D2 offers powerful, modern layout engines (like ELK and Dagre) that can be particularly effective for organizing large, complex data models automatically. This provides users with an alternative rendering backend that excels at creating clean, readable diagrams from complex schemas.

As a text-based format, D2 diagrams are also highly portable and easy to version control alongside source code.

For more information on D2's class diagrams, see the official tour: https://d2lang.com/tour/uml-classes

### Implementation

- A new `to_d2()` method has been added to the `EntityRelationshipDiagram` class.
- A corresponding `--d2` / `-D` CLI flag has been added to generate D2 output to stdout.
- The implementation maps `erdantic`'s model and relationship metadata to D2's UML class shape syntax, including field visibility based on Python naming conventions (`_` for protected, `__` for private).

### Usage and Example Output

The commands below generate a `diagram.d2` file from the `pydantic` models and then render it into an SVG:

```bash
# Generate D2 output for the pydantic example models
erdantic --d2 erdantic.examples.pydantic.Party > diagram.d2

# Render the diagram to SVG using the D2 CLI
d2 diagram.d2 diagram.svg
```

Here is the resulting `diagram.svg`:

![diagram](https://github.com/user-attachments/assets/a90ab947-9657-4099-9b32-d72e25914a7e)

<br>

<details>
<summary><b>Layout Engine Comparison on a Complex Diagram</b></summary>

To showcase the power of D2's layout engines, here are renderings of a more complex diagram using `dagre`, `elk`, and `tala`.

**1. Dagre (Default Layout)**
`d2 -l dagre complex.d2 d2_dagre.svg`

![d2_dagre](https://github.com/user-attachments/assets/53fcaca8-b4a3-4aca-8159-fcb166e8ea56)

---

**2. ELK Layout**
`d2 -l elk complex.d2 d2_elk.svg`

![d2_elk](https://github.com/user-attachments/assets/2a751c68-c072-4a32-86d4-ac01220b87bd)

---

**3. TALA Layout**
`d2 -l tala complex.d2 d2_tala.svg`

![d2_tala](https://github.com/user-attachments/assets/fc2e67f5-4afb-46e0-a13d-38f2c41d47f8)

</details>