### PR TITLE
Clarify what erdantic diagrams represent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## v1.2.0 (2025-09-15)
 
-- Added support for the D2 diagramming language for class diagrams. Use `EntityRelationshipDiagram.to_d2()` to get the D2 representation programmatically, or the CLI flag `--d2` to print it to stdout. The `--dot` and `--d2` options are mutually exclusive, and `-o`/`--out` is ignored when `--d2` is used. ([PR #152](https://github.com/drivendataorg/erdantic/pull/152) and [PR #162](https://github.com/drivendataorg/erdantic/pull/162), contribution thanks to [@Else00](https://github.com/Else00))
+- Added support for the [D2 diagramming language](https://d2lang.com/). Use `EntityRelationshipDiagram.to_d2()` to get the D2 representation programmatically, or the CLI flag `--d2` to print it to stdout. The `--dot` and `--d2` options are mutually exclusive, and `-o`/`--out` is ignored when `--d2` is used. ([PR #152](https://github.com/drivendataorg/erdantic/pull/152) and [PR #162](https://github.com/drivendataorg/erdantic/pull/162), contribution thanks to [@Else00](https://github.com/Else00))
 
 ## v1.1.1 (2025-07-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Removed support for Python 3.9. ([PR #171](https://github.com/drivendataorg/erdantic/pull/171))
 
+### Documentation
+
+- Added "How to read the diagram" section to the README. ([PR #172](https://github.com/drivendataorg/erdantic/pull/172))
+- Removed misleading "class diagram" language from D2 output docstrings and help text. ([PR #172](https://github.com/drivendataorg/erdantic/pull/172))
+
+
 ## v1.2.1 (2026-02-15)
 
 - Added official support for Python 3.14. ([PR #164](https://github.com/drivendataorg/erdantic/pull/164))

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ Diagrams are rendered using the [Graphviz](https://graphviz.org/) library. We al
 
 You can use erdantic either as a convenient CLI or as a Python library. Great for adding a simple and clean data model reference to your documentation.
 
-## What gets diagrammed
-
 <object type="image/svg+xml" data="https://raw.githubusercontent.com/drivendataorg/erdantic/refs/heads/main/docs/docs/assets/example_diagram.svg" width="100%" typemustmatch><img alt="Example diagram created by erdantic" src="https://raw.githubusercontent.com/drivendataorg/erdantic/refs/heads/main/docs/docs/assets/example_diagram.svg"></object>
+
+Type annotations are formatted using the [typenames](https://github.com/drivendataorg/typenames) library.
+
+## What gets diagrammed
 
 erdantic creates **entity relationship diagrams (ERDs)** which show the compositional relationship between data model classes. These are classes whose primary purpose is to be a structured typed container of key–value data. They are the nodes in the diagram. The edges represent the type annotation of a field on one class referencing another class (i.e., the first class ["contains"](https://en.wikipedia.org/wiki/Object_composition#Programming_technique) the second class). Edges use [crow's foot notation](https://erdantic.drivendata.org/stable/customizing/#customizing-edges) for representing the cardinality and modality of the relationships.
 
-Type annotations are formatted using the [typenames](https://github.com/drivendataorg/typenames) library.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can use erdantic either as a convenient CLI or as a Python library. Great fo
 
 Type annotations are formatted using the [typenames](https://github.com/drivendataorg/typenames) library.
 
-## What gets diagrammed
+## How to read the diagram
 
 erdantic creates **entity relationship diagrams (ERDs)** which show the compositional relationship between data model classes. These are classes whose primary purpose is to be a structured typed container of key–value data. They are the nodes in the diagram. The edges represent the type annotation of a field on one class referencing another class (i.e., the first class ["contains"](https://en.wikipedia.org/wiki/Object_composition#Programming_technique) the second class). Edges use [crow's foot notation](https://erdantic.drivendata.org/stable/customizing/#customizing-edges) for representing the cardinality and modality of the relationships.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Type annotations are formatted using the [typenames](https://github.com/drivenda
 
 erdantic creates **entity relationship diagrams (ERDs)** which show the compositional relationship between data model classes. These are classes whose primary purpose is to be a structured typed container of key–value data. They are the nodes in the diagram. The edges represent the type annotation of a field on one class referencing another class (i.e., the first class ["contains"](https://en.wikipedia.org/wiki/Object_composition#Programming_technique) the second class). Edges use [crow's foot notation](https://erdantic.drivendata.org/stable/customizing/#customizing-edges) for representing the cardinality and modality of the relationships.
 
-
 ## Installation
 
 erdantic's graph modeling depends on [pygraphviz](https://pygraphviz.github.io/documentation/stable/index.html) and [Graphviz](https://graphviz.org/), an open-source C library. If you are on Linux or macOS, the easiest way to install everything together is to use conda and conda-forge:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Type annotations are formatted using the [typenames](https://github.com/drivenda
 
 ## How to read the diagram
 
-erdantic creates **entity relationship diagrams (ERDs)** which show the compositional relationship between data model classes. These are classes whose primary purpose is to be a structured typed container of key–value data. They are the nodes in the diagram. The edges represent the type annotation of a field on one class referencing another class (i.e., the first class ["contains"](https://en.wikipedia.org/wiki/Object_composition#Programming_technique) the second class). Edges use [crow's foot notation](https://erdantic.drivendata.org/stable/customizing/#customizing-edges) for representing the cardinality and modality of the relationships.
+Each **node** in the diagram is a data model class: a class whose primary purpose is to hold data in a declared set of typed fields. Each **edge** is a compositional relationship, meaning a field on one class has a type annotation referencing another class, so that the first class ["contains"](https://en.wikipedia.org/wiki/Object_composition#Programming_technique) the second. Edges use [crow's foot notation](https://erdantic.drivendata.org/stable/customizing/#customizing-edges) to represent the cardinality and modality of each relationship.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![tests](https://github.com/drivendataorg/erdantic/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/drivendataorg/erdantic/actions/workflows/tests.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/drivendataorg/erdantic/branch/main/graph/badge.svg)](https://codecov.io/gh/drivendataorg/erdantic)
 
-**erdantic** is a simple tool for drawing [entity relationship diagrams (ERDs)](https://en.wikipedia.org/wiki/Data_modeling#Entity%E2%80%93relationship_diagrams) for Python data model classes. Diagrams are rendered using the [Graphviz](https://graphviz.org/) library. Supported data modeling frameworks are:
+**erdantic** is a simple tool for drawing [entity relationship diagrams (ERDs)](https://en.wikipedia.org/wiki/Data_modeling#Entity%E2%80%93relationship_diagrams) for Python data model classes. Supported data modeling frameworks are:
 
 - [Pydantic V2](https://docs.pydantic.dev/latest/)
 - [Pydantic V1 legacy](https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features)
@@ -15,11 +15,15 @@
 - [msgspec](https://jcristharif.com/msgspec/)
 - [dataclasses](https://docs.python.org/3/library/dataclasses.html) from the Python standard library
 
-We also support [D2](https://d2lang.com/) as an alternative output format.
+Diagrams are rendered using the [Graphviz](https://graphviz.org/) library. We also support [D2](https://d2lang.com/) as an alternative output format.
 
 You can use erdantic either as a convenient CLI or as a Python library. Great for adding a simple and clean data model reference to your documentation.
 
+## What gets diagrammed
+
 <object type="image/svg+xml" data="https://raw.githubusercontent.com/drivendataorg/erdantic/refs/heads/main/docs/docs/assets/example_diagram.svg" width="100%" typemustmatch><img alt="Example diagram created by erdantic" src="https://raw.githubusercontent.com/drivendataorg/erdantic/refs/heads/main/docs/docs/assets/example_diagram.svg"></object>
+
+erdantic creates **entity relationship diagrams (ERDs)** which show the compositional relationship between data model classes. These are classes whose primary purpose is to be a structured typed container of key–value data. They are the nodes in the diagram. The edges represent the type annotation of a field on one class referencing another class (i.e., the first class ["contains"](https://en.wikipedia.org/wiki/Object_composition#Programming_technique) the second class). Edges use [crow's foot notation](https://erdantic.drivendata.org/stable/customizing/#customizing-edges) for representing the cardinality and modality of the relationships.
 
 Type annotations are formatted using the [typenames](https://github.com/drivendataorg/typenames) library.
 

--- a/erdantic/cli.py
+++ b/erdantic/cli.py
@@ -147,7 +147,7 @@ def main(
             "--d2",
             callback=d2_callback,
             help=(
-                "Print out D2 language representation for a class diagram to console "
+                "Print out D2 language representation to console "
                 "instead of rendering an image. The --out option will be ignored."
             ),
         ),

--- a/erdantic/core.py
+++ b/erdantic/core.py
@@ -679,7 +679,7 @@ class EntityRelationshipDiagram(pydantic.BaseModel):
         ).string()
 
     def to_d2(self) -> str:
-        """Generate D2 class diagram representation of the entity relationship diagram.
+        """Generate D2 diagramming language representation of the entity relationship diagram.
 
         Returns:
             str: D2 language representation of diagram

--- a/erdantic/d2.py
+++ b/erdantic/d2.py
@@ -56,7 +56,7 @@ _REL_DEF_TEMPLATE = dedent(
 
 
 def render_d2(diagram: EntityRelationshipDiagram) -> str:
-    """Renders an EntityRelationshipDiagram into the D2 class diagram format."""
+    """Renders an EntityRelationshipDiagram into the D2 diagram format."""
     d2_parts: list[str] = []
 
     # Define all class shapes first


### PR DESCRIPTION
- Add "How to read the diagram" section to README
- Remove misleading references to "class diagram" in D2 documentation