### PR TITLE
fix: resolve PEP 695 type aliases when walking annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.3.0 (Unreleased)
 
 - Removed support for Python 3.9. ([PR #171](https://github.com/drivendataorg/erdantic/pull/171))
+- Fixed type aliases declared with Python 3.12's `type` statement (PEP 695) not being resolved, which meant models referenced through such an alias were missing from the diagram. ([Issue #118](https://github.com/drivendataorg/erdantic/issues/118))
 
 ### Documentation
 

--- a/erdantic/typing_utils.py
+++ b/erdantic/typing_utils.py
@@ -1,6 +1,16 @@
 import collections.abc
 import sys
-from typing import Any, ForwardRef, Iterator, Literal, TypeVar, Union, get_args, get_origin
+from typing import (
+    Any,
+    ForwardRef,
+    Iterator,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
 
 from typenames import BaseNode, GenericNode, parse_type_tree
 
@@ -22,10 +32,19 @@ else:
     _TypeForm = TypeVar("_TypeForm", bound=Union[type, str, object])
 
 
-def _resolve_type_alias(tp: Any) -> Any:
+def _resolve_type_alias(tp: Any, seen: Optional[set[int]] = None) -> Any:
     """Unwrap a PEP 695 type alias (``type X = ...``) to the type it stands for. Aliases can be
-    chained, so unwrap repeatedly. Non-alias annotations are returned unchanged."""
+    chained, so unwrap repeatedly. Non-alias annotations are returned unchanged.
+
+    Aliases can also be cyclic (``type A = B`` / ``type B = A``) or self-referential
+    (``type Rec = list[Rec]``). Track the aliases already unwrapped and stop at the first repeat,
+    returning that alias unresolved, so resolution always terminates.
+    """
+    local_seen = seen if seen is not None else set()
     while isinstance(tp, TypeAliasType):
+        if id(tp) in local_seen:
+            return tp
+        local_seen.add(id(tp))
         tp = tp.__value__
     return tp
 
@@ -86,8 +105,16 @@ def get_depth1_bases(tp: type) -> list[type]:
 def get_recursive_args(tp: _TypeForm) -> list[_TypeForm]:
     """Recursively finds leaf-node types of possibly-nested generic type."""
 
-    def recurse(t: _TypeForm) -> Iterator[_TypeForm]:
-        t = _resolve_type_alias(t)
+    def recurse(t: _TypeForm, seen: set[int]) -> Iterator[_TypeForm]:
+        # Copy so that sibling branches do not share the alias path of one another.
+        seen = set(seen)
+        resolved = _resolve_type_alias(t, seen)
+        if isinstance(resolved, TypeAliasType):
+            # Cyclic or self-referential alias already unwrapped on this path; stop here rather
+            # than recursing forever.
+            yield resolved  # type: ignore [misc]
+            return
+        t = resolved
         if isinstance(t, str):
             raise _UnevaluatedForwardRefError(forward_ref=t)
         elif isinstance(t, ForwardRef):
@@ -108,11 +135,11 @@ def get_recursive_args(tp: _TypeForm) -> list[_TypeForm]:
         args = get_args(t)
         if args:
             for arg in args:
-                yield from recurse(arg)
+                yield from recurse(arg, seen)
         else:
             yield t
 
-    return list(recurse(tp))
+    return list(recurse(tp, set()))
 
 
 def repr_type_with_mro(obj: Any) -> str:

--- a/erdantic/typing_utils.py
+++ b/erdantic/typing_utils.py
@@ -6,6 +6,11 @@ from typenames import BaseNode, GenericNode, parse_type_tree
 
 from erdantic.exceptions import _UnevaluatedForwardRefError
 
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+else:
+    from typing_extensions import TypeAliasType
+
 # TypeVar for type annotations
 # Most typing special forms have type 'object'
 # There is a stalled proposal for TypeForm: https://github.com/python/mypy/issues/9773
@@ -17,8 +22,19 @@ else:
     _TypeForm = TypeVar("_TypeForm", bound=Union[type, str, object])
 
 
+def _resolve_type_alias(tp: Any) -> Any:
+    """Unwrap a PEP 695 type alias (``type X = ...``) to the type it stands for. Aliases can be
+    chained, so unwrap repeatedly. Non-alias annotations are returned unchanged."""
+    while isinstance(tp, TypeAliasType):
+        tp = tp.__value__
+    return tp
+
+
 def _walk_type_tree(node: BaseNode, target: type) -> bool:
     """Recursively walk a type tree to check if type is many in target type."""
+    resolved = _resolve_type_alias(node.tp)
+    if resolved is not node.tp:
+        node = parse_type_tree(resolved)
     if isinstance(node, GenericNode):
         if isinstance(node.origin, type) and (
             issubclass(node.origin, collections.abc.Container)
@@ -57,6 +73,7 @@ def is_nullable_type(tp: _TypeForm) -> bool:
     Returns:
         bool: Result of check.
     """
+    tp = _resolve_type_alias(tp)
     return get_origin(tp) is Union and type(None) in get_args(tp)
 
 
@@ -70,6 +87,7 @@ def get_recursive_args(tp: _TypeForm) -> list[_TypeForm]:
     """Recursively finds leaf-node types of possibly-nested generic type."""
 
     def recurse(t: _TypeForm) -> Iterator[_TypeForm]:
+        t = _resolve_type_alias(t)
         if isinstance(t, str):
             raise _UnevaluatedForwardRefError(forward_ref=t)
         elif isinstance(t, ForwardRef):

--- a/tests/test_typing_utils.py
+++ b/tests/test_typing_utils.py
@@ -1,3 +1,4 @@
+import sys
 import typing
 
 import pytest
@@ -10,6 +11,11 @@ from erdantic.typing_utils import (
     is_nullable_type,
     repr_type_with_mro,
 )
+
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+else:
+    from typing_extensions import TypeAliasType
 
 
 def test_is_collection_type_of():
@@ -70,6 +76,31 @@ def test_get_recursive_args():
     # Resolve forward reference
     resolved_annotations = typing.get_type_hints(Model, localns=locals())
     assert get_recursive_args(resolved_annotations["field"]) == [SomeForwardRef]
+
+
+class _AliasTarget: ...
+
+
+_many_alias = TypeAliasType("_many_alias", typing.List[_AliasTarget])
+_chained_alias = TypeAliasType("_chained_alias", _many_alias)
+_optional_alias = TypeAliasType("_optional_alias", typing.Optional[_AliasTarget])
+
+
+def test_pep695_type_aliases():
+    """Type aliases declared with PEP 695's `type` statement should be transparent.
+
+    https://github.com/drivendataorg/erdantic/issues/118
+    """
+    assert get_recursive_args(_many_alias) == [_AliasTarget]
+    assert get_recursive_args(_chained_alias) == [_AliasTarget]
+    assert get_recursive_args(typing.List[_many_alias]) == [_AliasTarget]
+
+    assert is_collection_type_of(_many_alias, _AliasTarget)
+    assert is_collection_type_of(_chained_alias, _AliasTarget)
+    assert not is_collection_type_of(_optional_alias, _AliasTarget)
+
+    assert is_nullable_type(_optional_alias)
+    assert not is_nullable_type(_many_alias)
 
 
 def test_get_depth1_bases():

--- a/tests/test_typing_utils.py
+++ b/tests/test_typing_utils.py
@@ -137,3 +137,29 @@ def test_repr_type_with_mro():
         == "<mro (tests.test_typing_utils.test_repr_type_with_mro.<locals>.FancyInt, int, object)>"
     )
     assert repr_type_with_mro(FancyInt()) == repr(FancyInt())
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="PEP 695 `type` statement requires Python 3.12"
+)
+def test_pep695_cyclic_type_aliases():
+    """Cyclic and self-referential aliases should terminate instead of hanging.
+
+    Only the `type` statement produces lazily evaluated values, so these cannot be built with
+    the `TypeAliasType(...)` constructor.
+    """
+    namespace: dict = {}
+    exec(
+        "type _cycle_a = _cycle_b\n"
+        "type _cycle_b = _cycle_a\n"
+        "type _self_ref = list[_self_ref]\n",
+        namespace,
+    )
+    cycle_a = namespace["_cycle_a"]
+    self_ref = namespace["_self_ref"]
+
+    assert get_recursive_args(cycle_a) == [cycle_a]
+    assert get_recursive_args(self_ref) == [self_ref]
+    assert not is_nullable_type(cycle_a)
+    assert not is_collection_type_of(cycle_a, _AliasTarget)
+    assert is_collection_type_of(self_ref, self_ref)


### PR DESCRIPTION
Closes #118

`type X = ...` aliases are `TypeAliasType` objects, which are opaque to `typing.get_args()` and to `typenames.parse_type_tree()`, so recursion stopped at the alias and the model behind it was never discovered — the field produced no edge and the inner model was missing from the diagram. Unwrapping `__value__` (in a loop, since aliases can chain) in `get_recursive_args`, `is_nullable_type`, and `_walk_type_tree` makes aliases transparent for discovery as well as for the cardinality/modality checks.

`test_pep695_type_aliases` fails on the current code and passes with the fix. `TypeAliasType` is imported from `typing_extensions` below 3.12, which is already a dependency there.
