### PR TITLE
Execute notebooks when building docs site

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build notebook artifacts
         run: |
-          run-notebooks
+          just run-notebooks
 
       - name: Deploy as latest
         if: github.event.inputs.deploy-as == 'latest' || github.event_name == 'push'

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           git fetch origin gh-pages --depth=1
 
+      - name: Build notebook artifacts
+        run: |
+          run-notebooks
+
       - name: Deploy as latest
         if: github.event.inputs.deploy-as == 'latest' || github.event_name == 'push'
         working-directory: docs/


### PR DESCRIPTION
Fixes missing notebooks in the v1.1 and v1.2 versions of the site. 